### PR TITLE
Refactor SPA views with bento cards

### DIFF
--- a/siteScripts/components/bentoCards.js
+++ b/siteScripts/components/bentoCards.js
@@ -1,0 +1,133 @@
+import { ICONS } from "../map.js";
+
+const escapeHtml = (value = "") => String(value)
+  .replace(/&/g, "&amp;")
+  .replace(/</g, "&lt;")
+  .replace(/>/g, "&gt;")
+  .replace(/"/g, "&quot;")
+  .replace(/'/g, "&#39;");
+
+const serializePayload = (payload) => {
+  if (!payload) return "";
+  try {
+    return JSON.stringify(payload)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  } catch (error) {
+    return "";
+  }
+};
+
+const buildMedia = ({ cover, alt, badge, action, icon, accent }) => {
+  const hasCover = Boolean(cover);
+  return `
+    <div class="bento-card-media ${accent ? `media-${accent}` : ""}">
+      ${hasCover ? `<img src="${escapeHtml(cover)}" alt="${escapeHtml(alt || "Artwork")}" loading="lazy"/>` : `<div class="bento-card-media-placeholder"></div>`}
+      ${badge ? `<span class="bento-card-chip">${escapeHtml(badge)}</span>` : ""}
+      ${action ? `<button type="button" class="bento-card-cta" data-action="${escapeHtml(action)}" aria-label="${escapeHtml(action.replace(/-/g, " "))}">${icon || ICONS.play}</button>` : ""}
+    </div>
+  `;
+};
+
+const buildFooter = (actions = []) => {
+  if (!actions.length) return "";
+  const html = actions
+    .map(({ label, action, variant = "ghost" }) => {
+      const classes = variant === "solid" ? "btn-solid" : variant === "icon" ? "btn-icon" : "btn-ghost";
+      const content = variant === "icon" ? (action === "favorite-album" ? ICONS.heart : ICONS.more) : escapeHtml(label);
+      return `<button type="button" class="bento-card-action ${classes}" data-action="${escapeHtml(action)}">${content}</button>`;
+    })
+    .join("");
+  return `<div class="bento-card-footer">${html}</div>`;
+};
+
+const typeRenderers = {
+  artist: (data) => {
+    const kicker = data.kicker || "Artist";
+    const metaParts = [data.genre, data.statLine].filter(Boolean);
+    return `
+      ${buildMedia({ cover: data.cover, alt: data.name, badge: data.badge, action: "play-artist", icon: ICONS.play, accent: "artist" })}
+      <div class="bento-card-body">
+        <p class="bento-card-kicker">${escapeHtml(kicker)}</p>
+        <h3 class="bento-card-title">${escapeHtml(data.name)}</h3>
+        ${metaParts.length ? `<p class="bento-card-meta">${escapeHtml(metaParts.join(" • "))}</p>` : ""}
+      </div>
+      ${buildFooter([
+        { label: "View Artist", action: "view-artist", variant: "ghost" },
+        { label: "Favorite", action: "favorite-artist", variant: "icon" },
+      ])}
+    `;
+  },
+  album: (data) => {
+    const metaParts = [data.artist, data.year ? `Released ${data.year}` : null, data.songCount ? `${data.songCount} songs` : null].filter(Boolean);
+    return `
+      ${buildMedia({ cover: data.cover, alt: data.title, badge: data.year, action: "play-album", icon: ICONS.play, accent: "album" })}
+      <div class="bento-card-body">
+        <p class="bento-card-kicker">${escapeHtml(data.artist || "Album")}</p>
+        <h3 class="bento-card-title">${escapeHtml(data.title)}</h3>
+        ${metaParts.length ? `<p class="bento-card-meta">${escapeHtml(metaParts.join(" • "))}</p>` : ""}
+      </div>
+      ${buildFooter([
+        { label: "Open Album", action: "view-album", variant: "ghost" },
+        { label: "Favorite", action: "favorite-album", variant: "icon" },
+      ])}
+    `;
+  },
+  song: (data) => {
+    const metaParts = [data.artist, data.duration].filter(Boolean);
+    return `
+      ${buildMedia({ cover: data.cover, alt: data.title, badge: data.trackNumber ? `#${data.trackNumber}` : data.album, action: "play-song", icon: ICONS.play })}
+      <div class="bento-card-body">
+        <p class="bento-card-kicker">${escapeHtml(data.album || "Single")}</p>
+        <h3 class="bento-card-title">${escapeHtml(data.title)}</h3>
+        ${metaParts.length ? `<p class="bento-card-meta">${escapeHtml(metaParts.join(" • "))}</p>` : ""}
+      </div>
+      ${buildFooter([
+        { label: "Queue", action: "queue-song", variant: "ghost" },
+        { label: "Favorite", action: "favorite-song", variant: "icon" },
+      ])}
+    `;
+  },
+  playlist: (data) => {
+    const metaParts = [data.songCount ? `${data.songCount} songs` : null, data.updatedLabel].filter(Boolean);
+    return `
+      ${buildMedia({ cover: data.cover, alt: data.name, badge: data.badge || "Playlist", action: "play-playlist", icon: ICONS.play, accent: "playlist" })}
+      <div class="bento-card-body">
+        <p class="bento-card-kicker">${escapeHtml(data.owner || "Curated")}</p>
+        <h3 class="bento-card-title">${escapeHtml(data.name)}</h3>
+        ${metaParts.length ? `<p class="bento-card-meta">${escapeHtml(metaParts.join(" • "))}</p>` : ""}
+      </div>
+      ${buildFooter([
+        { label: "Open", action: "view-playlist", variant: "ghost" },
+        { label: "Favorite", action: "favorite-playlist", variant: "icon" },
+      ])}
+    `;
+  },
+};
+
+export const BentoCards = {
+  renderCard(type, config = {}) {
+    const renderer = typeRenderers[type];
+    if (!renderer) return "";
+    const payload = config.payload || null;
+    const attributes = [
+      `class="bento-card bento-card--${type}${config.highlight ? ` ${config.highlight}` : ""}"`,
+      `data-card-type="${type}"`,
+      payload ? `data-payload="${serializePayload(payload)}"` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return `<article ${attributes}>${renderer(config)}</article>`;
+  },
+  renderCollection(items = []) {
+    return items
+      .map((item) => {
+        if (!item) return "";
+        const type = item.type || "song";
+        return BentoCards.renderCard(type, item.data || item);
+      })
+      .join("");
+  },
+};

--- a/siteScripts/global.js
+++ b/siteScripts/global.js
@@ -2368,67 +2368,11 @@ loadAudioFile: async (songData) => {
     updateHomeBentoGrid: () => {
       const dynamicContent = $byId(IDS.dynamicContent);
       if (!dynamicContent) return;
-      
-      const bentoGrid = dynamicContent.querySelector('.bento-grid');
-      if (!bentoGrid) return;
-      
-      const recentlyPlayedSection = $byId(IDS.recentlyPlayedSection);
-      if (recentlyPlayedSection && appState.recentlyPlayed && appState.recentlyPlayed.length > 0) {
-        const recentTracksHtml = render.homeSection.recentlyPlayed(
-          appState.recentlyPlayed.slice(0, 5),
-          utils
-        );
-        recentlyPlayedSection.innerHTML = recentTracksHtml;
-        
-        musicPlayer.ui.bindHomeBentoEvents(recentlyPlayedSection);
-      }
-    },
-    
-    bindHomeBentoEvents: (container) => {
-      if (!container) return;
-      
-      container.querySelectorAll('.modern-track-item, .track-play-btn').forEach(item => {
-        item.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const songDataStr = item.closest('[data-song]')?.dataset.song;
-          if (songDataStr) {
-            try {
-              const songData = JSON.parse(songDataStr);
-              musicPlayer.ui.playSong(songData);
-            } catch (error) {
-              console.error('Error parsing song data:', error);
-            }
-          }
-        });
-      });
-      
-      container.querySelectorAll('[data-artist]').forEach(artistEl => {
-        artistEl.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const artistName = artistEl.dataset.artist;
-          if (appState.router) {
-            appState.router.navigateTo(ROUTES.ARTIST, { artist: artistName });
-          }
-        });
-      });
-      
-      container.querySelectorAll('.track-favorite-btn, .favorite-heart-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const songItem = btn.closest('[data-song]');
-          if (songItem) {
-            const songDataStr = songItem.dataset.song;
-            try {
-              const songData = JSON.parse(songDataStr);
-              appState.favorites.toggle('songs', songData.id);
-              
-              btn.classList.toggle('active', appState.favorites.has('songs', songData.id));
-            } catch (error) {
-              console.error('Error toggling favorite:', error);
-            }
-          }
-        });
-      });
+
+      const homeViewRoot = dynamicContent.querySelector('[data-view-id="home-view"]');
+      if (!homeViewRoot) return;
+
+      homePage.renderRecentlyPlayed();
     },
     
     updateRecentTab: () => {
@@ -3737,127 +3681,23 @@ const playlists = {
         playlists.bindEvents(modalEl);
     },
 
-    show: (playlistId) => {
-        const playlist = appState.playlists.find((p) => p.id === playlistId);
-        if (!playlist) {
+    show: (playlistId, options = {}) => {
+        if (!playlistId) {
             notifications.notify({ type: NOTIFICATION_TYPES.ERROR, message: "Playlist not found" });
             return;
         }
 
-        pageLoader.start({ message: "Loading playlist..." });
+        const skipRouting = options.skipRouting ?? false;
+        const currentState = window.history.state;
+        const isCurrent = currentState?.name === ROUTES.PLAYLIST && currentState?.params?.playlistId === playlistId;
 
-        setTimeout(() => {
-            const dynamicContent = $byId(IDS.dynamicContent);
-            if (!dynamicContent) return;
+        if (!skipRouting && appState.router && !isCurrent) {
+            appState.router.navigateTo(ROUTES.PLAYLIST, { playlistId });
+            return;
+        }
 
-            dynamicContent.innerHTML = `
-                <div class="playlist-page animate__animated animate__fadeIn">
-                  <div class="playlist-header mb-8 flex items-start gap-6">
-                    <div class="playlist-cover w-48 h-48 bg-gradient-to-br from-purple-500 to-blue-600 rounded-lg flex items-center justify-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" class="w-24 h-24">
-                        <path d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v2H3v-2zM17 6v8.18c-.31-.11-.65-.18-1-.18-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3V8h3V6h-5z"/>
-                      </svg>
-                    </div>
-                    <div class="playlist-info flex-1">
-                      <p class="text-sm text-gray-400 mb-2">PLAYLIST</p>
-                      <h1 class="text-4xl font-bold mb-4">${playlist.name}</h1>
-                      <p class="text-gray-400 mb-6">${playlist.songs.length} song${playlist.songs.length !== 1 ? "s" : ""} • Created ${new Date(playlist.created).toLocaleDateString()}</p>
-                      <div class="flex gap-4">
-                        <button class="play-playlist-btn bg-accent-primary text-white px-8 py-3 rounded-full hover:bg-accent-secondary transition-colors flex items-center gap-2" data-playlist-id="${playlist.id}" ${
-            playlist.songs.length === 0 ? "disabled" : ""
-          }>
-                          ${ICONS.play}
-                          Play
-                        </button>
-                        <button class="edit-playlist-btn bg-gray-600 text-white px-6 py-3 rounded-full hover:bg-gray-500 transition-colors" data-playlist-id="${playlist.id}">
-                          Edit
-                        </button>
-                        <button class="delete-playlist-btn bg-red-600 text-white px-6 py-3 rounded-full hover:bg-red-700 transition-colors" data-playlist-id="${playlist.id}">
-                          Delete
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  ${
-                    playlist.songs.length === 0
-                      ? `
-                    <div class="empty-playlist text-center py-12">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-16 h-16 mx-auto mb-4 text-gray-600">
-                        <path d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v2H3v-2zM17 6v8.18c-.31-.11-.65-.18-1-.18-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3V8h3V6h-5z"/>
-                      </svg>
-                      <h3 class="text-xl font-bold mb-2">This playlist is empty</h3>
-                      <p class="text-gray-400 mb-4">Add songs to start building your playlist</p>
-                      <button class="browse-music-btn bg-accent-primary text-white px-6 py-2 rounded-full hover:bg-accent-secondary transition-colors">
-                        Browse Music
-                      </button>
-                    </div>
-                  `
-                      : `
-                    <div class="songs-list">
-                      <div class="songs-header grid grid-cols-12 gap-4 px-4 py-2 text-sm text-gray-400 border-b border-gray-700 mb-2">
-                        <div class="col-span-1">#</div>
-                        <div class="col-span-5">Title</div>
-                        <div class="col-span-3 hidden md:block">Album</div>
-                        <div class="col-span-2 hidden md:block">Date Added</div>
-                        <div class="col-span-1">Duration</div>
-                      </div>
-                      ${playlist.songs
-                        .map(
-                          (song, index) => `
-                        <div class="song-row grid grid-cols-12 gap-4 items-center px-4 py-3 rounded-lg hover:bg-white/5 transition-colors cursor-pointer group" data-song='${JSON.stringify(song).replace(/'/g, "&apos;")}' data-playlist-id="${
-                            playlist.id
-                          }" data-song-index="${index}">
-                          <div class="col-span-1 text-gray-400 group-hover:hidden">${index + 1}</div>
-                          <div class="col-span-1 hidden group-hover:block">
-                            <button class="play-song-btn w-8 h-8 bg-accent-primary rounded-full flex items-center justify-center hover:scale-110 transition-transform">
-                              ${ICONS.play}
-                            </button>
-                          </div>
-                          <div class="col-span-5 flex items-center gap-3">
-                            <img src="${utils.getAlbumImageUrl(song.album)}" alt="${song.title}" class="w-10 h-10 rounded object-cover">
-                            <div>
-                              <div class="font-medium">${song.title}</div>
-                              <div class="text-sm text-gray-400 cursor-pointer hover:text-white transition-colors" data-artist="${song.artist}">${song.artist}</div>
-                            </div>
-                          </div>
-                          <div class="col-span-3 hidden md:block text-gray-400 text-sm">${song.album}</div>
-                          <div class="col-span-2 hidden md:block text-gray-400 text-sm">${new Date().toLocaleDateString()}</div>
-                          <div class="col-span-1 flex items-center justify-between">
-                            <span class="text-gray-400 text-sm">${song.duration || "0:00"}</span>
-                            <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
-                              <button class="action-btn p-1 hover:bg-white/10 rounded transition-colors" data-action="favorite" data-song-id="${song.id}" title="Add to favorites">
-                                <svg class="w-4 h-4 ${appState.favorites.has("songs", song.id) ? "text-red-500" : ""}" fill="${appState.favorites.has("songs", song.id) ? "currentColor" : "none"}" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
-                                </svg>
-                              </button>
-                              <button class="action-btn p-1 hover:bg-white/10 rounded transition-colors" data-action="add-queue" title="Add to queue">
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
-                                </svg>
-                              </button>
-                              <button class="action-btn p-1 hover:bg-white/10 rounded transition-colors" data-action="remove-from-playlist" title="Remove from playlist">
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-                      `
-                        )
-                        .join("")}
-                    </div>
-                  `
-                  }
-                </div>
-              `;
-
-            playlists.bindViewEvents(playlist);
-            pageLoader.complete();
-        }, 200);
+        navigation.pages.loadPlaylistPage(playlistId);
     },
-
     bindEvents: (root = $byId(IDS.dynamicContent)) => {
         const dynamicContent = root;
         if (!dynamicContent) return;

--- a/siteScripts/map.js
+++ b/siteScripts/map.js
@@ -296,6 +296,7 @@ export const ROUTES = Object.freeze({
   ALL_ARTISTS: "allArtists",
   SEARCH: "search",
   ALBUM: "album",
+  PLAYLIST: "playlist",
 });
 
 export const STORAGE_KEYS = Object.freeze({

--- a/siteScripts/pages/rendering.js
+++ b/siteScripts/pages/rendering.js
@@ -1,12 +1,25 @@
-import { appState, storage, notifications, musicPlayer, utils, ACTION_GRID_ITEMS, overlays } from "../global.js";
+import { appState, notifications, musicPlayer, utils, overlays, playlists } from "../global.js";
+import { IDS, ROUTES, NOTIFICATION_TYPES, $byId } from "../map.js";
+import { pageUpdates } from "./updates.js";
+import { render } from "../utilities/templates.js";
+import { BentoCards } from "../components/bentoCards.js";
 
-import { ui, pageUpdates } from "./updates.js";
-import { render, create } from "../utilities/templates.js";
+const delay = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
 
-import { deepLinkRouter } from "./router.js";
+export const escapeForAttribute = function (str = "") {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/'/g, "&#39;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+};
 
-export const escapeForAttribute = function (str) {
-  return str.replace(/&/g, "&amp;").replace(/'/g, "&#39;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const viewContext = {
+  type: "home",
+  artist: null,
+  album: null,
+  playlist: null,
 };
 
 export const pageLoader = {
@@ -18,6 +31,14 @@ export const pageLoader = {
   startedAt: 0,
   progress: 0,
   timers: [],
+  activeOptions: null,
+
+  defaultOptions: {
+    showBar: true,
+    showSpinner: true,
+    blurContent: true,
+    message: "Loading...",
+  },
 
   pacing: {
     minActiveMs: 800,
@@ -25,7 +46,7 @@ export const pageLoader = {
     completionLingerMs: 300,
   },
 
-  init: function () {
+  init() {
     if (!pageLoader.bar) {
       const bar = document.createElement("div");
       bar.className = "loading-bar";
@@ -53,7 +74,11 @@ export const pageLoader = {
     }
 
     if (!pageLoader.contentContainer) {
-      pageLoader.contentContainer = document.querySelector("#dynamic-content") || document.querySelector("#main-content") || document.querySelector("main") || document.body;
+      pageLoader.contentContainer =
+        document.querySelector("#dynamic-content") ||
+        document.querySelector("#main-content") ||
+        document.querySelector("main") ||
+        document.body;
 
       if (pageLoader.contentContainer && !pageLoader.contentContainer.classList.contains("content-blur-container")) {
         pageLoader.contentContainer.classList.add("content-blur-container");
@@ -61,40 +86,53 @@ export const pageLoader = {
     }
   },
 
-  start: function (options = {}) {
+  start(options = {}) {
     pageLoader.init();
     pageLoader.clearTimers();
     pageLoader.isActive = true;
     pageLoader.progress = 0;
     pageLoader.startedAt = Date.now();
 
-    const message = options.message || "Loading...";
+    pageLoader.activeOptions = { ...pageLoader.defaultOptions, ...options };
+    const { showBar, showSpinner, blurContent, message } = pageLoader.activeOptions;
 
     if (pageLoader.loadingText) {
       pageLoader.loadingText.textContent = message;
     }
 
     const bar = pageLoader.bar;
-    bar.classList.remove("complete");
-    bar.style.transform = "scaleX(0)";
-    bar.style.opacity = "0";
-
-    pageLoader.centerOverlay.classList.add("active");
-
-    if (pageLoader.contentContainer) {
-      pageLoader.contentContainer.classList.add("blur-active");
+    if (bar) {
+      bar.classList.remove("complete");
+      bar.style.transform = "scaleX(0)";
+      bar.style.opacity = "0";
     }
 
-    setTimeout(function () {
-      bar.classList.add("active");
-      bar.style.opacity = "1";
-      bar.style.transform = "scaleX(0.1)";
-      pageLoader.animateProgressBar();
-    }, 50);
+    if (showSpinner && pageLoader.centerOverlay) {
+      pageLoader.centerOverlay.classList.add("active");
+    } else if (pageLoader.centerOverlay) {
+      pageLoader.centerOverlay.classList.remove("active");
+    }
+
+    if (pageLoader.contentContainer) {
+      if (blurContent) {
+        pageLoader.contentContainer.classList.add("blur-active");
+      } else {
+        pageLoader.contentContainer.classList.remove("blur-active");
+      }
+    }
+
+    if (showBar && bar) {
+      setTimeout(() => {
+        bar.classList.add("active");
+        bar.style.opacity = "1";
+        bar.style.transform = "scaleX(0.1)";
+        pageLoader.animateProgressBar();
+      }, 50);
+    }
   },
 
-  animateProgressBar: function () {
-    if (!pageLoader.isActive) return;
+  animateProgressBar() {
+    if (!pageLoader.isActive || pageLoader.activeOptions?.showBar === false || !pageLoader.bar) return;
 
     const intervals = [
       { duration: 200, progress: 0.1 },
@@ -106,13 +144,13 @@ export const pageLoader = {
 
     let currentProgress = 0.1;
 
-    intervals.forEach(function (interval, index) {
-      const timer = setTimeout(function () {
-        if (!pageLoader.isActive) return;
+    intervals.forEach((interval, index) => {
+      const timer = setTimeout(() => {
+        if (!pageLoader.isActive || pageLoader.activeOptions?.showBar === false) return;
 
         currentProgress = interval.progress;
         pageLoader.progress = currentProgress;
-        pageLoader.bar.style.transform = "scaleX(" + currentProgress + ")";
+        pageLoader.bar.style.transform = `scaleX(${currentProgress})`;
 
         if (index === intervals.length - 1) {
           pageLoader.startFinalCrawl();
@@ -123,71 +161,85 @@ export const pageLoader = {
     });
   },
 
-  startFinalCrawl: function () {
-    if (!pageLoader.isActive) return;
+  startFinalCrawl() {
+    if (!pageLoader.isActive || pageLoader.activeOptions?.showBar === false || !pageLoader.bar) return;
 
     const crawlDuration = 2000 + Math.random() * 1000;
     const startTime = Date.now();
 
-    function crawl() {
-      if (!pageLoader.isActive) return;
+    const crawl = () => {
+      if (!pageLoader.isActive || pageLoader.activeOptions?.showBar === false) return;
 
       const elapsed = Date.now() - startTime;
       const progress = 0.9 + 0.09 * (elapsed / crawlDuration);
 
       if (progress < 0.99) {
         pageLoader.progress = progress;
-        pageLoader.bar.style.transform = "scaleX(" + progress + ")";
-
+        pageLoader.bar.style.transform = `scaleX(${progress})`;
         const timer = setTimeout(crawl, 50);
         pageLoader.timers.push(timer);
       }
-    }
+    };
 
     const timer = setTimeout(crawl, 50);
     pageLoader.timers.push(timer);
   },
 
-  complete: function () {
-    if (!pageLoader.isActive || !pageLoader.bar) return;
+  complete() {
+    if (!pageLoader.isActive) {
+      return Promise.resolve();
+    }
 
     const elapsed = Date.now() - pageLoader.startedAt;
     const minDuration = pageLoader.pacing.minActiveMs;
     const waitTime = Math.max(0, minDuration - elapsed);
 
-    function finalize() {
-      pageLoader.bar.style.transform = "scaleX(1)";
-      pageLoader.bar.classList.add("complete");
-
-      if (pageLoader.contentContainer) {
-        pageLoader.contentContainer.classList.remove("blur-active");
-      }
-
-      setTimeout(function () {
-        pageLoader.centerOverlay.classList.remove("active");
-      }, 100);
-
-      setTimeout(function () {
-        pageLoader.bar.classList.remove("active", "complete");
-        pageLoader.bar.style.opacity = "0";
-        pageLoader.isActive = false;
-        pageLoader.clearTimers();
-
-        if (pageLoader.loadingText) {
-          pageLoader.loadingText.textContent = "Loading...";
+    return new Promise((resolve) => {
+      const finalize = () => {
+        if (pageLoader.activeOptions?.showBar !== false && pageLoader.bar) {
+          pageLoader.bar.style.transform = "scaleX(1)";
+          pageLoader.bar.classList.add("complete");
         }
-      }, pageLoader.pacing.completionLingerMs);
-    }
 
-    if (waitTime > 0) {
-      const timer = setTimeout(finalize, waitTime);
-      pageLoader.timers.push(timer);
-    } else {
-      finalize();
-    }
+        if (pageLoader.contentContainer && pageLoader.activeOptions?.blurContent !== false) {
+          pageLoader.contentContainer.classList.remove("blur-active");
+        }
+
+        const spinnerTimer = setTimeout(() => {
+          if (pageLoader.activeOptions?.showSpinner !== false && pageLoader.centerOverlay) {
+            pageLoader.centerOverlay.classList.remove("active");
+          }
+        }, 100);
+        pageLoader.timers.push(spinnerTimer);
+
+        const cleanupTimer = setTimeout(() => {
+          if (pageLoader.bar) {
+            pageLoader.bar.classList.remove("active", "complete");
+            pageLoader.bar.style.opacity = "0";
+            pageLoader.bar.style.transform = "scaleX(0)";
+          }
+          pageLoader.isActive = false;
+          pageLoader.clearTimers();
+          pageLoader.activeOptions = null;
+
+          if (pageLoader.loadingText) {
+            pageLoader.loadingText.textContent = "Loading...";
+          }
+          resolve();
+        }, pageLoader.pacing.completionLingerMs);
+        pageLoader.timers.push(cleanupTimer);
+      };
+
+      if (waitTime > 0) {
+        const timer = setTimeout(finalize, waitTime);
+        pageLoader.timers.push(timer);
+      } else {
+        finalize();
+      }
+    });
   },
 
-  hide: function () {
+  hide() {
     pageLoader.isActive = false;
     pageLoader.clearTimers();
 
@@ -208,836 +260,1053 @@ export const pageLoader = {
     if (pageLoader.loadingText) {
       pageLoader.loadingText.textContent = "Loading...";
     }
+
+    pageLoader.activeOptions = null;
   },
 
-  clearTimers: function () {
-    pageLoader.timers.forEach(function (timer) {
-      clearTimeout(timer);
-    });
+  clearTimers() {
+    pageLoader.timers.forEach((timer) => clearTimeout(timer));
     pageLoader.timers = [];
   },
 
-  setPacing: function (options) {
+  setPacing(options) {
     Object.assign(pageLoader.pacing, options);
   },
 
-  setMessage: function (message) {
+  setMessage(message) {
     if (pageLoader.loadingText) {
       pageLoader.loadingText.textContent = message;
     }
   },
+
+  async wrapAsync(task, options = {}) {
+    pageLoader.start(options);
+    try {
+      return await task();
+    } catch (error) {
+      console.error("PageLoader task failed", error);
+      throw error;
+    } finally {
+      await pageLoader.complete();
+    }
+  },
+};
+
+export const PageLoader = pageLoader;
+
+const ensureArray = (value) => (Array.isArray(value) ? value : []);
+
+const renderingHelpers = {
+  getDynamicContent() {
+    return $byId(IDS.dynamicContent);
+  },
+
+  renderViewShell(config) {
+    const container = renderingHelpers.getDynamicContent();
+    if (!container) return null;
+    container.innerHTML = render.viewShell(config);
+    return container.querySelector("[data-view-grid]");
+  },
+
+  renderHeroSection(config) {
+    if (!config) return "";
+    const statsHtml = ensureArray(config.stats)
+      .map((stat) => {
+        if (!stat?.label) return "";
+        return `
+          <div class="view-hero-stat">
+            <p class="view-hero-stat-value">${escapeForAttribute(stat.value ?? "")}</p>
+            <p class="view-hero-stat-label">${escapeForAttribute(stat.label)}</p>
+          </div>
+        `;
+      })
+      .join("");
+
+    const actionsHtml = ensureArray(config.actions)
+      .map((action) => {
+        if (!action?.label || !action?.action) return "";
+        const variant = action.variant || "solid";
+        return `<button type="button" class="view-hero-btn view-hero-btn--${variant}" data-section-action="${escapeForAttribute(
+          action.action
+        )}">${escapeForAttribute(action.label)}</button>`;
+      })
+      .join("");
+
+    return `
+      <div class="view-hero" data-section-id="${escapeForAttribute(config.id || "view-hero")}">
+        <div class="view-hero-cover">
+          <img src="${escapeForAttribute(config.cover)}" alt="${escapeForAttribute(config.title)}" loading="lazy"/>
+        </div>
+        <div class="view-hero-body">
+          ${config.kicker ? `<p class="view-hero-eyebrow">${escapeForAttribute(config.kicker)}</p>` : ""}
+          <h2 class="view-hero-title">${escapeForAttribute(config.title)}</h2>
+          ${config.subtitle ? `<p class="view-hero-subtitle">${escapeForAttribute(config.subtitle)}</p>` : ""}
+          ${statsHtml ? `<div class="view-hero-stats">${statsHtml}</div>` : ""}
+          ${actionsHtml ? `<div class="view-hero-actions">${actionsHtml}</div>` : ""}
+        </div>
+      </div>
+    `;
+  },
+
+  renderSection(sectionConfig = {}) {
+    if (!sectionConfig.id) return "";
+    const hasCards = Boolean(sectionConfig.cardsHtml);
+    const content = hasCards
+      ? sectionConfig.cardsHtml
+      : sectionConfig.emptyState || renderingHelpers.renderEmptyState(sectionConfig.emptyConfig);
+
+    return `
+      <div class="view-section" data-section-id="${escapeForAttribute(sectionConfig.id)}">
+        <div class="view-section-header">
+          <div>
+            <h2>${escapeForAttribute(sectionConfig.title || "")}</h2>
+            ${sectionConfig.description ? `<p class="view-section-description">${escapeForAttribute(sectionConfig.description)}</p>` : ""}
+          </div>
+          ${sectionConfig.action ? `<div class="view-section-actions"><button type="button" data-section-action="${escapeForAttribute(
+            sectionConfig.action.action
+          )}">${escapeForAttribute(sectionConfig.action.label)}</button></div>` : ""}
+        </div>
+        <div class="bento-grid">
+          ${content}
+        </div>
+      </div>
+    `;
+  },
+
+  renderEmptyState(config = {}) {
+    if (!config.title && !config.message) return "";
+    return `
+      <div class="view-section-empty">
+        ${config.title ? `<h3>${escapeForAttribute(config.title)}</h3>` : ""}
+        ${config.message ? `<p>${escapeForAttribute(config.message)}</p>` : ""}
+        ${config.action ? `<button type="button" data-section-action="${escapeForAttribute(config.action.action)}">${escapeForAttribute(
+          config.action.label
+        )}</button>` : ""}
+      </div>
+    `;
+  },
+
+  buildSongCards(songs = []) {
+    const cards = songs.map((song, index) => ({
+      type: "song",
+      data: {
+        title: song.title,
+        album: song.album,
+        artist: song.artist,
+        duration: song.duration || "0:00",
+        cover: song.cover,
+        trackNumber: song.trackNumber ?? index + 1,
+        payload: song,
+      },
+    }));
+    return BentoCards.renderCollection(cards);
+  },
+
+  buildAlbumCards(albums = []) {
+    const cards = albums.map((album) => ({
+      type: "album",
+      data: {
+        title: album.album,
+        artist: album.artist,
+        year: album.year || "—",
+        songCount: ensureArray(album.songs).length,
+        cover: album.cover || utils.getAlbumImageUrl(album.album),
+        payload: album,
+      },
+    }));
+    return BentoCards.renderCollection(cards);
+  },
+
+  buildArtistCards(artists = []) {
+    const cards = artists.map((artist) => ({
+      type: "artist",
+      data: {
+        name: artist.artist,
+        genre: artist.genre || "Various",
+        statLine: `${ensureArray(artist.albums).length} albums`,
+        cover: artist.cover || utils.getArtistImageUrl(artist.artist),
+        payload: { artist: artist.artist },
+      },
+    }));
+    return BentoCards.renderCollection(cards);
+  },
+
+  buildPlaylistSongCards(playlist) {
+    const songs = ensureArray(playlist?.songs).map((song, index) => ({
+      ...song,
+      cover: song.cover || utils.getAlbumImageUrl(song.album),
+      trackNumber: index + 1,
+    }));
+    return renderingHelpers.buildSongCards(songs);
+  },
+
+  findArtist(name) {
+    if (!name || !window.music) return null;
+    return window.music.find((artist) => artist.artist.toLowerCase() === name.toLowerCase()) || null;
+  },
+
+  findAlbum(artistInput, albumName) {
+    if (!artistInput || !albumName) return null;
+    const artistData = typeof artistInput === "string" ? renderingHelpers.findArtist(artistInput) : artistInput;
+    if (!artistData) return null;
+    const album = ensureArray(artistData.albums).find((entry) => entry.album.toLowerCase() === albumName.toLowerCase());
+    if (!album) return null;
+    return { artist: artistData, album };
+  },
+
+  collectArtistSongs(artistData) {
+    if (!artistData) return [];
+    const songs = [];
+    ensureArray(artistData.albums).forEach((album) => {
+      ensureArray(album.songs).forEach((song) => {
+        songs.push({
+          ...song,
+          artist: artistData.artist,
+          album: album.album,
+          cover: song.cover || utils.getAlbumImageUrl(album.album),
+        });
+      });
+    });
+    return songs;
+  },
 };
 
 export const navigation = {
-  initialize: function () {
-    pageLoader.init();
+  viewContext,
 
+  initialize() {
+    PageLoader.init();
     appState.router = navigation.createRouter();
 
-    window.addEventListener("popstate", function () {
-      appState.router.handleRoute(window.location.pathname + window.location.search);
+    window.addEventListener("popstate", (event) => {
+      const state = event.state;
+      if (state?.routeName) {
+        appState.router.executeRoute(state.routeName, state.params || {}, { skipHistory: true });
+      } else {
+        appState.router.handleRoute(window.location.pathname, { replaceState: true });
+      }
     });
 
     appState.router.handleInitialRoute();
   },
 
-  createRouter: function () {
+  createRouter() {
     const router = {
-      // Helper to encode names (spaces to periods)
-      encodeName: function (name) {
+      routes: {},
+
+      encodeName(name = "") {
         return name.trim().replace(/\s+/g, ".");
       },
-      // Helper to decode names (periods to spaces)
-      decodeName: function (segment) {
+
+      decodeName(segment = "") {
         return segment.replace(/\./g, " ");
       },
 
-      routes: {},
-
-      handleInitialRoute: function () {
-        const path = window.location.pathname + window.location.search;
-        this.handleRoute(path);
-      },
-
-      handleRoute: function (path) {
-        let matchedRoute = false;
-        for (const key in this.routes) {
-          const route = this.routes[key];
-          const match = path.match(route.pattern);
-          if (match) {
-            const params = {};
-            if (key === ROUTES.ARTIST) params.artist = router.decodeName(match[1]);
-            route.handler(params);
-            matchedRoute = true;
-            break;
-          }
-        }
-        if (!matchedRoute) navigation.pages.loadHomePage();
-      },
-
-      navigateTo: function (routeName, params = {}) {
-        let url;
+      buildUrl(routeName, params = {}) {
         switch (routeName) {
           case ROUTES.HOME:
-            url = "/";
-            break;
+            return "/";
           case ROUTES.ARTIST:
-            url = "/artist/" + router.encodeName(params.artist);
-            break;
+            return `/artist/${router.encodeName(params.artist || "")}`;
           case ROUTES.ALL_ARTISTS:
-            url = "/artists";
-            break;
+            return "/artists";
+          case ROUTES.ALBUM:
+            return `/album/${router.encodeName(params.artist || "")}/${router.encodeName(params.album || "")}`;
+          case ROUTES.PLAYLIST:
+            return `/playlist/${params.playlistId || ""}`;
           default:
-            url = "/";
+            return "/";
         }
-        window.history.pushState({}, "", url);
-        if (this.routes[routeName]) this.routes[routeName].handler(params);
       },
 
-      navigateToArtist: function (artistName) {
+      handleInitialRoute() {
+        const match = this.matchPath(window.location.pathname) || { routeName: ROUTES.HOME, params: {} };
+        window.history.replaceState(match, "", window.location.pathname);
+        this.executeRoute(match.routeName, match.params, { skipHistory: true });
+      },
+
+      matchPath(path) {
+        const normalized = path.split("?")[0];
+        for (const key in this.routes) {
+          const route = this.routes[key];
+          const match = normalized.match(route.pattern);
+          if (match) {
+            const params = route.parse ? route.parse(match) : {};
+            return { routeName: key, params };
+          }
+        }
+        return null;
+      },
+
+      handleRoute(path, options = {}) {
+        const match = this.matchPath(path) || { routeName: ROUTES.HOME, params: {} };
+        if (options.replaceState) {
+          window.history.replaceState(match, "", path);
+        }
+        this.executeRoute(match.routeName, match.params, { skipHistory: true });
+      },
+
+      executeRoute(routeName, params = {}, options = {}) {
+        const route = this.routes[routeName];
+        if (route && typeof route.handler === "function") {
+          route.handler(params, options);
+        } else {
+          navigation.pages.loadHomePage();
+        }
+      },
+
+      navigateTo(routeName, params = {}, options = {}) {
+        if (!navigation.isValidRoute(routeName, params)) {
+          this.executeRoute(ROUTES.HOME, {});
+          return;
+        }
+
+        const url = this.buildUrl(routeName, params);
+        const state = { routeName, params };
+        if (options.replace) {
+          window.history.replaceState(state, "", url);
+        } else {
+          window.history.pushState(state, "", url);
+        }
+        this.executeRoute(routeName, params, { skipHistory: true });
+      },
+
+      navigateToArtist(artistName) {
         this.navigateTo(ROUTES.ARTIST, { artist: artistName });
       },
 
-      openSearchDialog: function () {
+      openSearchDialog() {
         notifications.show("Search functionality coming soon");
       },
 
-      closeSearchDialog: function () {},
+      closeSearchDialog() {},
     };
 
-    // Now define the routes using `router` variable so helpers are always accessible
     router.routes = {
       [ROUTES.HOME]: {
         pattern: /^\/$/,
         handler: navigation.pages.loadHomePage,
       },
       [ROUTES.ARTIST]: {
-        pattern: /^\/artist\/(.+)$/,
-        handler: function (params) {
-          // Use router.decodeName instead of this.decodeName
-          const artistName = params.artist || utils.getParameterByName("artist", window.location.href);
-          const decodedArtistName = artistName ? router.decodeName(artistName) : "";
-          const artistData = window.music?.find(function (a) {
-            return a.artist === decodedArtistName;
-          });
-          if (artistData) {
-            navigation.pages.loadArtistPage(artistData);
-          } else {
-            appState.router.navigateTo(ROUTES.HOME);
-          }
-        },
+        pattern: /^\/artist\/([^/]+)$/,
+        parse: (match) => ({ artist: router.decodeName(match[1]) }),
+        handler: ({ artist }) => navigation.pages.loadArtistPage(artist),
       },
       [ROUTES.ALL_ARTISTS]: {
         pattern: /^\/artists$/,
         handler: navigation.pages.loadAllArtistsPage,
+      },
+      [ROUTES.ALBUM]: {
+        pattern: /^\/album\/([^/]+)\/([^/]+)$/,
+        parse: (match) => ({ artist: router.decodeName(match[1]), album: router.decodeName(match[2]) }),
+        handler: ({ artist, album }) => navigation.pages.loadAlbumPage({ artist, album }),
+      },
+      [ROUTES.PLAYLIST]: {
+        pattern: /^\/playlist\/([^/]+)$/,
+        parse: (match) => ({ playlistId: match[1] }),
+        handler: ({ playlistId }) => navigation.pages.loadPlaylistPage(playlistId),
       },
     };
 
     return router;
   },
 
-  isValidRoute: function (routeName, params = {}) {
+  isValidRoute(routeName, params = {}) {
     switch (routeName) {
       case ROUTES.HOME:
       case ROUTES.ALL_ARTISTS:
         return true;
-
       case ROUTES.ARTIST:
-        if (!params.artist || !window.music) return false;
-        return window.music.some(function (a) {
-          return a.artist === params.artist;
-        });
-
+        return Boolean(params.artist && renderingHelpers.findArtist(params.artist));
+      case ROUTES.ALBUM: {
+        if (!params.artist || !params.album) return false;
+        return Boolean(renderingHelpers.findAlbum(params.artist, params.album));
+      }
+      case ROUTES.PLAYLIST:
+        return Boolean(params.playlistId && appState.playlists.find((pl) => pl.id === params.playlistId));
       default:
         return false;
     }
   },
 
   pages: {
-    loadHomePage: function () {
-      pageLoader.start({ message: "Loading Music..." });
+    async loadHomePage() {
+      viewContext.type = "home";
+      viewContext.artist = null;
+      viewContext.album = null;
+      viewContext.playlist = null;
 
-      if (appState.homePageManager) {
-        const dynamicContent = $byId(IDS.dynamicContent);
-        if (dynamicContent) {
-          dynamicContent.innerHTML = "";
-        }
+      await PageLoader.wrapAsync(async () => {
+        if (!appState.homePageManager) return;
+        await delay(50);
+        appState.homePageManager.renderHomePage();
 
-        setTimeout(function () {
-          appState.homePageManager.renderHomePage();
-
-          pageUpdates.breadCrumbs(
-            [
-              {
-                text: "Home",
-                route: ROUTES.HOME,
-                active: true,
-                isHome: true,
-                icon:
-                  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path d="M125.2 16.1c6.2-4.4 5.4-14.8-2.2-15.6c-3.6-.4-7.3-.5-11-.5C50.1 0 0 50.1 0 112s50.1 112 112 112c32.1 0 61.1-13.5 81.5-35.2c5.2-5.6-1-14-8.6-13.2c-2.9 .3-5.9 .4-9 .4c-48.6 0-88-39.4-88-88c0-29.7 14.7-55.9 37.2-71.9zm289.9 85.3c-8.8-7.2-21.5-7.2-30.3 0l-216 176c-10.3 8.4-11.8 23.5-3.4 33.8s23.5 11.8 33.8 3.4L224 294.4 224 456c0 30.9 25.1 56 56 56l240 0c30.9 0 56-25.1 56-56l0-161.6 24.8 20.2c10.3 8.4 25.4 6.8 33.8-3.4s6.8-25.4-3.4-33.8l-216-176zM528 255.3L528 456c0 4.4-3.6 8-8 8l-240 0c-4.4 0-8-3.6-8-8l0-200.7L400 151 528 255.3zM352 312l0 48c0 13.3 10.7 24 24 24l48 0c13.3 0 24-10.7 24-24l0-48c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24zM248.5 12.3L236.6 44.6 204.3 56.5c-7 2.6-7 12.4 0 15l32.3 11.9 11.9 32.3c2.6 7 12.4 7 15 0l11.9-32.3 32.3-11.9c7-2.6 7-12.4 0-15L275.4 44.6 263.5 12.3c-2.6-7-12.4-7-15 0zm-145 320c-2.6-7-12.4-7-15 0L76.6 364.6 44.3 376.5c-7 2.6-7 12.4 0 15l32.3 11.9 11.9 32.3c2.6 7 12.4 7 15 0l11.9-32.3 32.3-11.9c7-2.6 7-12.4 0-15l-32.3-11.9-11.9-32.3z"/></svg>',
-              },
-            ],
+        pageUpdates.breadCrumbs(
+          [
             {
-              showIcons: true,
-              truncateAfter: 3,
-              animateChanges: true,
-              schemaMarkup: true,
-            }
-          );
+              text: "Home",
+              route: ROUTES.HOME,
+              active: true,
+              isHome: true,
+              icon:
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path class="fa-secondary" d="M80 202.9L80 448c0 26.5 21.5 48 48 48l80 0 0-168c0-13.3 10.7-24 24-24l112 0c13.3 0 24 10.7 24 24l0 168 80 0c26.5 0 48-21.5 48-48l0-245.1L288 18.7 80 202.9z"/><path class="fa-primary" d="M293.3 2c-3-2.7-7.6-2.7-10.6 0L2.7 250c-3.3 2.9-3.6 8-.7 11.3s8 3.6 11.3 .7L64 217.1 64 448c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-230.9L562.7 262c3.3 2.9 8.4 2.6 11.3-.7s2.6-8.4-.7-11.3L293.3 2zM80 448l0-245.1L288 18.7 496 202.9 496 448c0 26.5-21.5 48-48 48l-80 0 0-168c0-13.3-10.7-24-24-24l-112 0c-13.3 0 24 10.7 24 24l0 168-80 0c-26.5 0-48-21.5-48-48zm144 48l0-168c0-4.4 3.6-8 8-8l112 0c4.4 0 8 3.6 8 8l0 168-128 0z"/></svg>',
+            },
+          ],
+          {
+            showIcons: true,
+            truncateAfter: 3,
+            animateChanges: true,
+            schemaMarkup: true,
+          }
+        );
 
-          setTimeout(function () {
-            pageLoader.complete();
-          }, 700);
-
-          utils.scrollToTop();
-        }, 200);
-      }
-    },
-
-    loadArtistPage: function (artistData, targetAlbumName = null) {
-      pageLoader.start({ message: "Finding Artist..." });
-
-      const dynamicContent = $byId(IDS.dynamicContent);
-      if (!dynamicContent) return;
-
-      dynamicContent.innerHTML = "";
-
-      setTimeout(function () {
-        navigation.rendering.renderArtistPage(artistData, targetAlbumName);
-        pageLoader.complete();
         utils.scrollToTop();
-      }, 200);
+      }, { message: "Loading Music..." });
     },
 
-    loadAllArtistsPage: function () {
-      pageLoader.start({ message: "Loading library..." });
+    async loadArtistPage(artistInput, targetAlbumName = null) {
+      const artistData = typeof artistInput === "string" ? renderingHelpers.findArtist(artistInput) : artistInput;
+      if (!artistData) {
+        appState.router?.navigateTo(ROUTES.HOME, {}, { replace: true });
+        return;
+      }
 
-      const dynamicContent = $byId(IDS.dynamicContent);
-      if (!dynamicContent || !window.music) return;
+      viewContext.type = "artist";
+      viewContext.artist = artistData;
+      viewContext.album = null;
+      viewContext.playlist = null;
 
-      dynamicContent.innerHTML = "";
+      await PageLoader.wrapAsync(async () => {
+        await delay(75);
+        const root = navigation.rendering.renderArtistView(artistData, targetAlbumName);
+        navigation.events.bindViewInteractions(root, { ...viewContext, targetAlbumName });
 
-      setTimeout(function () {
-        navigation.rendering.renderAllArtistsPage();
+        pageUpdates.breadCrumbs(
+          [
+            {
+              text: "Home",
+              route: ROUTES.HOME,
+              active: false,
+              isHome: true,
+            },
+            {
+              text: artistData.artist,
+              route: ROUTES.ARTIST,
+              artist: artistData.artist,
+              active: true,
+            },
+          ],
+          { showIcons: true, truncateAfter: 3, animateChanges: true, schemaMarkup: true }
+        );
 
-        setTimeout(function () {
-          pageLoader.complete();
-        }, 100);
-      }, 300);
+        utils.scrollToTop();
+      }, { message: "Finding Artist..." });
+    },
+
+    async loadAllArtistsPage() {
+      viewContext.type = "artists";
+      viewContext.artist = null;
+      viewContext.album = null;
+      viewContext.playlist = null;
+
+      await PageLoader.wrapAsync(async () => {
+        await delay(75);
+        const root = navigation.rendering.renderAllArtistsPage();
+        navigation.events.bindViewInteractions(root, { ...viewContext });
+
+        pageUpdates.breadCrumbs([
+          { text: "Home", route: ROUTES.HOME, active: false, isHome: true },
+          { text: "All Artists", route: ROUTES.ALL_ARTISTS, active: true },
+        ]);
+
+        utils.scrollToTop();
+      }, { message: "Loading library..." });
+    },
+
+    async loadAlbumPage(params = {}) {
+      const found = renderingHelpers.findAlbum(params.artist, params.album);
+      if (!found) {
+        appState.router?.navigateTo(ROUTES.HOME, {}, { replace: true });
+        return;
+      }
+
+      const { artist, album } = found;
+      viewContext.type = "album";
+      viewContext.artist = artist;
+      viewContext.album = album;
+      viewContext.playlist = null;
+
+      await PageLoader.wrapAsync(async () => {
+        await delay(75);
+        const root = navigation.rendering.renderAlbumPage(artist, album);
+        navigation.events.bindViewInteractions(root, { ...viewContext });
+
+        pageUpdates.breadCrumbs([
+          { text: "Home", route: ROUTES.HOME, active: false, isHome: true },
+          { text: artist.artist, route: ROUTES.ARTIST, artist: artist.artist, active: false },
+          { text: album.album, route: ROUTES.ALBUM, artist: artist.artist, album: album.album, active: true },
+        ]);
+
+        utils.scrollToTop();
+      }, { message: "Opening album..." });
+    },
+
+    async loadPlaylistPage(playlistId) {
+      const playlist = appState.playlists.find((pl) => pl.id === playlistId);
+      if (!playlist) {
+        notifications.notify({ type: NOTIFICATION_TYPES.ERROR, message: "Playlist not found" });
+        appState.router?.navigateTo(ROUTES.HOME, {}, { replace: true });
+        return;
+      }
+
+      viewContext.type = "playlist";
+      viewContext.artist = null;
+      viewContext.album = null;
+      viewContext.playlist = playlist;
+
+      await PageLoader.wrapAsync(async () => {
+        await delay(50);
+        const root = navigation.rendering.renderPlaylistPage(playlist);
+        navigation.events.bindViewInteractions(root, { ...viewContext });
+
+        pageUpdates.breadCrumbs([
+          { text: "Home", route: ROUTES.HOME, active: false, isHome: true },
+          { text: "Playlists", onClick: () => appState.router?.navigateTo(ROUTES.HOME), active: false },
+          { text: playlist.name, active: true },
+        ]);
+
+        utils.scrollToTop();
+      }, { message: "Loading playlist..." });
     },
   },
 
   rendering: {
-    renderArtistPage: function (artistData, targetAlbumName = null) {
-      const dynamicContent = $byId(IDS.dynamicContent);
-      if (!dynamicContent) return;
-
-      dynamicContent.innerHTML = render.artist("enhancedArtist", {
-        artist: artistData.artist,
-        cover: utils.getArtistImageUrl(artistData.artist),
-        genre: artistData.genre || "",
-        albumCount: artistData.albums.length,
-        songCount: utils.getTotalSongs(artistData),
-      });
-
-      navigation.rendering.setupAlbumsSection(artistData, targetAlbumName);
-
-      pageUpdates.breadCrumbs(
-        [
-          {
-            text: "Home  ",
-            route: ROUTES.HOME,
-            active: false,
-            isHome: true,
-            icon:
-              '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path class="fa-secondary" d="M80 202.9L80 448c0 26.5 21.5 48 48 48l80 0 0-168c0-13.3 10.7-24 24-24l112 0c13.3 0 24 10.7 24 24l0 168 80 0c26.5 0 48-21.5 48-48l0-245.1L288 18.7 80 202.9z"/><path class="fa-primary" d="M293.3 2c-3-2.7-7.6-2.7-10.6 0L2.7 250c-3.3 2.9-3.6 8-.7 11.3s8 3.6 11.3 .7L64 217.1 64 448c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-230.9L562.7 262c3.3 2.9 8.4 2.6 11.3-.7s2.6-8.4-.7-11.3L293.3 2zM80 448l0-245.1L288 18.7 496 202.9 496 448c0 26.5-21.5 48-48 48l-80 0 0-168c0-13.3-10.7-24-24-24l-112 0c-13.3 0 24 10.7 24 24l0 168-80 0c-26.5 0-48-21.5-48-48zm144 48l0-168c0-4.4 3.6-8 8-8l112 0c4.4 0 8 3.6 8 8l0 168-128 0z"/></svg>',
-          },
-          {
-            text: "  Discography",
-            route: ROUTES.ARTIST,
-            artist: artistData.artist,
-            active: true,
-            icon: "",
-          },
+    renderArtistView(artistData, targetAlbumName = null) {
+      const grid = renderingHelpers.renderViewShell({
+        viewId: "artist-view",
+        accentLabel: "Artist",
+        title: artistData.artist,
+        subtitle: `${artistData.genre || "Across genres"} • ${ensureArray(artistData.albums).length} albums • ${utils.getTotalSongs(
+          artistData
+        )} songs`,
+        actions: [
+          { label: "Play", action: "artist-play" },
+          { label: "Shuffle", action: "artist-shuffle" },
+          { label: "Favorite", action: "artist-favorite" },
         ],
-        { showIcons: true, truncateAfter: 3, animateChanges: true, schemaMarkup: true }
-      );
+      });
+      if (!grid) return null;
 
-      const names = utils.getSimilarArtists(artistData.artist, { limit: 24 });
-      navigation.rendering.buildSimilar(names);
-      navigation.events.bindArtistPageEvents(artistData);
-    },
+      const songs = renderingHelpers.collectArtistSongs(artistData).slice(0, 6);
+      const albums = ensureArray(artistData.albums).map((album) => ({
+        ...album,
+        artist: artistData.artist,
+        cover: album.cover || utils.getAlbumImageUrl(album.album),
+      }));
 
-    setupAlbumsSection: function (artistData, targetAlbumName = null) {
-      const albumsContainer = $byId(IDS.albumsContainer);
-      if (!albumsContainer || !artistData.albums.length) return;
-
-      albumsContainer.innerHTML = render.album("section", { albums: artistData.albums });
-
-      let targetAlbumIndex = 0;
       if (targetAlbumName) {
-        const index = artistData.albums.findIndex(function (album) {
-          return album.album === targetAlbumName;
+        albums.sort((a, b) => {
+          if (a.album === targetAlbumName) return -1;
+          if (b.album === targetAlbumName) return 1;
+          return 0;
         });
-        if (index !== -1) {
-          targetAlbumIndex = index;
-        }
       }
 
-      navigation.rendering.displaySingleAlbum(artistData, targetAlbumIndex);
-      navigation.events.bindAlbumSwitcher(artistData);
-    },
+      const similarNames = ensureArray(utils.getSimilarArtists?.(artistData.artist, { limit: 8 }))
+        .filter(Boolean)
+        .map((name) => renderingHelpers.findArtist(name) || { artist: name, albums: [], genre: "" })
+        .slice(0, 6)
+        .map((artist) => ({ ...artist, cover: utils.getArtistImageUrl(artist.artist) }));
 
-    displaySingleAlbum: function (artistData, albumIndex) {
-      const currentAlbumDisplay = $byId("current-album-display");
-      if (!currentAlbumDisplay || !artistData.albums[albumIndex]) return;
-
-      const album = artistData.albums[albumIndex];
-      currentAlbumDisplay.style.opacity = "0";
-      currentAlbumDisplay.style.transform = "translateY(10px)";
-
-      setTimeout(function () {
-        const albumId = (artistData.artist + "-" + album.album).replace(/\s+/g, "").toLowerCase();
-        currentAlbumDisplay.innerHTML = render.album("card", {
-          albumId: albumId,
-          album: album.album,
-          cover: utils.getAlbumImageUrl(album.album),
-          year: album.year || "Unknown",
-          songCount: album.songs.length,
-        });
-
-        navigation.rendering.renderAlbumSongs(currentAlbumDisplay, album, artistData.artist);
-        currentAlbumDisplay.style.opacity = "1";
-        currentAlbumDisplay.style.transform = "translateY(0)";
-      }, 250);
-    },
-
-    renderAlbumSongs: function (albumContainer, album, artistName) {
-      const songsContainer = albumContainer.querySelector(".songs-container");
-      if (!songsContainer) return;
-
-      songsContainer.innerHTML = "";
-
-      if (!album.songs || album.songs.length === 0) {
-        songsContainer.innerHTML = '<p class="empty-songs-message">No songs found in this album</p>';
-        return;
-      }
-
-      songsContainer._songsData = [];
-
-      album.songs.forEach(function (song, index) {
-        const songData = {
-          ...song,
-          artist: artistName,
-          album: album.album,
-          cover: utils.getAlbumImageUrl(album.album),
-        };
-
-        songsContainer._songsData.push(songData);
-
-        const isFavorite = appState.favorites.has("songs", song.id);
-        const songElement = create(
-          render.songItem({
-            trackNumber: index + 1,
-            title: song.title,
-            artist: artistName,
-            duration: song.duration || "0:00",
-            songData: songData,
-            context: "base",
-            isFavorite: isFavorite,
-            showTrackNumber: true,
-            showArtist: false,
-          })
-        );
-
-        songElement.dataset.index = index;
-
-        songsContainer.appendChild(songElement);
+      const heroHtml = renderingHelpers.renderHeroSection({
+        id: "artist-hero",
+        kicker: "Artist",
+        cover: utils.getArtistImageUrl(artistData.artist),
+        title: artistData.artist,
+        subtitle: `${artistData.genre || ""} • Since ${ensureArray(artistData.albums)[0]?.year || "—"}`,
+        stats: [
+          { label: "Albums", value: ensureArray(artistData.albums).length },
+          { label: "Tracks", value: utils.getTotalSongs(artistData) },
+          { label: "Favorites", value: appState.favorites.artists.has(artistData.artist) ? "★" : "—" },
+        ],
+        actions: [
+          { label: "Play Artist", action: "artist-play", variant: "solid" },
+          { label: "Add to Queue", action: "artist-queue", variant: "ghost" },
+        ],
       });
 
-      navigation.events.bindSongItemEvents(songsContainer);
+      const sections = [
+        heroHtml,
+        renderingHelpers.renderSection({
+          id: "artist-top-songs",
+          title: "Popular songs",
+          description: "Handpicked essentials for an instant vibe.",
+          cardsHtml: songs.length ? renderingHelpers.buildSongCards(songs) : "",
+          emptyConfig: { title: "No songs yet", message: "This artist needs songs added to the catalog." },
+        }),
+        renderingHelpers.renderSection({
+          id: "artist-albums",
+          title: "Albums",
+          description: "Dive deeper into full-length releases.",
+          cardsHtml: albums.length ? renderingHelpers.buildAlbumCards(albums) : "",
+          emptyConfig: { title: "No albums", message: "Albums for this artist will show up here." },
+        }),
+        renderingHelpers.renderSection({
+          id: "artist-similar",
+          title: "Fans also like",
+          description: "Neighbors across your sonic universe.",
+          cardsHtml: similarNames.length ? renderingHelpers.buildArtistCards(similarNames) : "",
+          emptyConfig: { title: "No recommendations", message: "Add more artists to unlock smarter recs." },
+        }),
+      ].filter(Boolean);
+
+      grid.innerHTML = sections.join("");
+      return grid.closest("#" + IDS.dynamicContent) || grid;
     },
 
-    buildSimilar: function (names) {
-      const rows = document.querySelectorAll(".similar-rows .names-row");
-      const base = Array.from(
-        new Set(
-          (names || [])
-            .map(function (n) {
-              return String(n);
+    renderAllArtistsPage() {
+      const grid = renderingHelpers.renderViewShell({
+        viewId: "all-artists-view",
+        accentLabel: "Browse",
+        title: "All artists",
+        subtitle: "Every artist in your library, unified in one adaptive grid.",
+        actions: [{ label: "Back to Home", action: "go-home" }],
+      });
+      if (!grid) return null;
+
+      const artists = ensureArray(window.music).map((artist) => ({
+        ...artist,
+        cover: utils.getArtistImageUrl(artist.artist),
+      }));
+
+      const cardsHtml = artists.length
+        ? renderingHelpers.buildArtistCards(artists)
+        : renderingHelpers.renderEmptyState({ title: "No artists", message: "Import music to get started." });
+
+      grid.innerHTML = renderingHelpers.renderSection({
+        id: "all-artists-grid",
+        title: "Artists",
+        description: "Tap any card to jump into their discography.",
+        cardsHtml,
+      });
+
+      return grid.closest("#" + IDS.dynamicContent) || grid;
+    },
+
+    renderAlbumPage(artistData, album) {
+      const grid = renderingHelpers.renderViewShell({
+        viewId: "album-view",
+        accentLabel: "Album",
+        title: album.album,
+        subtitle: `${artistData.artist} • ${album.year || "Unknown"} • ${ensureArray(album.songs).length} songs`,
+        actions: [
+          { label: "Play", action: "album-play" },
+          { label: "Queue", action: "album-queue" },
+          { label: "Favorite", action: "album-favorite" },
+        ],
+      });
+      if (!grid) return null;
+
+      const enrichedSongs = ensureArray(album.songs).map((song, index) => ({
+        ...song,
+        artist: artistData.artist,
+        album: album.album,
+        cover: song.cover || utils.getAlbumImageUrl(album.album),
+        trackNumber: index + 1,
+      }));
+
+      const heroHtml = renderingHelpers.renderHeroSection({
+        id: "album-hero",
+        kicker: artistData.artist,
+        cover: utils.getAlbumImageUrl(album.album),
+        title: album.album,
+        subtitle: `${album.year || "Unknown release"} • ${enrichedSongs.length} tracks`,
+        stats: [
+          { label: "Duration", value: utils.getAlbumDuration?.(album) || "—" },
+          { label: "Favorites", value: appState.favorites.albums.has(album.album) ? "★" : "—" },
+        ],
+        actions: [
+          { label: "Play Album", action: "album-play", variant: "solid" },
+          { label: "Add to Queue", action: "album-queue", variant: "ghost" },
+        ],
+      });
+
+      const moreAlbums = ensureArray(artistData.albums)
+        .filter((item) => item.album !== album.album)
+        .map((item) => ({ ...item, artist: artistData.artist, cover: utils.getAlbumImageUrl(item.album) }))
+        .slice(0, 6);
+
+      const sections = [
+        heroHtml,
+        renderingHelpers.renderSection({
+          id: "album-tracklist",
+          title: "Tracklist",
+          description: "Tap any song to start playing instantly.",
+          cardsHtml: enrichedSongs.length ? renderingHelpers.buildSongCards(enrichedSongs) : "",
+          emptyConfig: { title: "No tracks", message: "This album has no songs yet." },
+        }),
+        moreAlbums.length
+          ? renderingHelpers.renderSection({
+              id: "album-more-from",
+              title: `More from ${artistData.artist}`,
+              description: "Continue exploring the discography.",
+              cardsHtml: renderingHelpers.buildAlbumCards(moreAlbums),
             })
-            .filter(Boolean)
-        )
-      );
-      if (!rows.length || !base.length) return;
+          : "",
+      ].filter(Boolean);
 
-      rows.forEach(function (row) {
-        const speed = parseFloat(row.dataset.speed || "30") || 30;
-        const gap = parseInt(row.dataset.gap || "18", 10) || 18;
-        const track = document.createElement("div");
-        const copyA = document.createElement("div");
-        const copyB = document.createElement("div");
+      grid.innerHTML = sections.join("");
+      return grid.closest("#" + IDS.dynamicContent) || grid;
+    },
 
-        track.className = "names-track";
-        copyA.className = "names-copy";
-        copyB.className = "names-copy";
-        track.style.setProperty("--speed", speed + "s");
-        track.style.setProperty("--gap", gap + "px");
-
-        base.forEach(function (n) {
-          copyA.appendChild(navigation.rendering.createArtistPill(n));
-        });
-        const rotated = base.length > 1 ? base.slice(1).concat(base[0]) : base.slice();
-        rotated.forEach(function (n) {
-          copyB.appendChild(navigation.rendering.createArtistPill(n));
-        });
-
-        row.innerHTML = "";
-        track.appendChild(copyA);
-        track.appendChild(copyB);
-        row.appendChild(track);
-
-        navigation.rendering.syncRowWidth(row, copyA, gap);
-        const ro = new ResizeObserver(function () {
-          navigation.rendering.syncRowWidth(row, copyA, gap);
-        });
-        ro.observe(row);
+    renderPlaylistPage(playlist) {
+      const cover = playlist.songs[0]?.cover || utils.getDefaultAlbumImage?.() || utils.getAlbumImageUrl(playlist.songs[0]?.album);
+      const grid = renderingHelpers.renderViewShell({
+        viewId: "playlist-view",
+        accentLabel: "Playlist",
+        title: playlist.name,
+        subtitle: `${playlist.songs.length} songs • Created ${new Date(playlist.created || Date.now()).toLocaleDateString()}`,
+        actions: [
+          { label: "Play", action: "playlist-play" },
+          { label: "Add Songs", action: "playlist-browse" },
+          { label: "Delete", action: "playlist-delete" },
+        ],
       });
-    },
+      if (!grid) return null;
 
-    createArtistPill: function (name) {
-      const a = document.createElement("a");
-      a.className = "name-pill";
-      a.href = "#";
-      a.dataset.artist = name;
-      const h4 = document.createElement("h4");
-      h4.textContent = name;
-      a.appendChild(h4);
-      a.addEventListener("click", function (e) {
-        e.preventDefault();
-        if (appState.router) {
-          appState.router.navigateToArtist(name);
-        }
+      const heroHtml = renderingHelpers.renderHeroSection({
+        id: "playlist-hero",
+        kicker: "Your playlist",
+        cover,
+        title: playlist.name,
+        subtitle: `${playlist.songs.length} tracks curated by you`,
+        stats: [
+          { label: "Songs", value: playlist.songs.length },
+          { label: "Created", value: new Date(playlist.created || Date.now()).toLocaleDateString() },
+        ],
+        actions: [
+          { label: "Play playlist", action: "playlist-play", variant: "solid" },
+          { label: "Queue all", action: "playlist-queue", variant: "ghost" },
+        ],
       });
-      return a;
-    },
 
-    syncRowWidth: function (row, copyA, gap) {
-      const items = Array.from(copyA.children);
-      if (!items.length) return;
-      const contentWidth = items.reduce(function (w, el) {
-        return w + el.getBoundingClientRect().width;
-      }, 0);
-      const totalGaps = Math.max(items.length - 1, 0) * gap;
-      const half = contentWidth + totalGaps;
-      const trackEl = row.querySelector(".names-track");
-      if (trackEl) trackEl.style.width = half * 2 + "px";
-    },
+      const hasSongs = playlist.songs.length > 0;
+      const sections = [
+        heroHtml,
+        renderingHelpers.renderSection({
+          id: "playlist-songs",
+          title: "Songs",
+          description: hasSongs ? "Tap a card to play or open actions for more." : "", 
+          cardsHtml: hasSongs ? renderingHelpers.buildPlaylistSongCards(playlist) : "",
+          emptyConfig: {
+            title: "No songs",
+            message: "Add tracks to this playlist to start listening.",
+            action: { label: "Browse music", action: "playlist-browse" },
+          },
+        }),
+      ];
 
-    renderAllArtistsPage: function () {
-      const dynamicContent = $byId(IDS.dynamicContent);
-      if (!dynamicContent || !window.music) return;
-
-      dynamicContent.innerHTML = render.page("allArtists");
-
-      const artistsGrid = $byId(IDS.artistsGrid);
-      if (artistsGrid) {
-        window.music.forEach(function (artist, index) {
-          const artistCard = document.createElement("div");
-          artistCard.className = "animate__animated animate__fadeIn";
-          artistCard.style.animationDelay = 0.05 * index + "s";
-
-          artistCard.innerHTML = render.artist("card", {
-            id: artist.artist.replace(/\s+/g, "").toLowerCase(),
-            artist: artist.artist,
-            cover: utils.getArtistImageUrl(artist.artist),
-            genre: artist.genre || "Various",
-            albumCount: artist.albums.length,
-          });
-
-          artistsGrid.appendChild(artistCard);
-
-          artistCard.querySelector(".artist-card").addEventListener("click", function () {
-            appState.router.navigateTo(ROUTES.ARTIST, { artist: artist.artist });
-          });
-        });
-      }
-
-      pageUpdates.breadCrumbs([
-        {
-          text: "Home",
-          route: ROUTES.HOME,
-          active: false,
-          isHome: true,
-        },
-        {
-          text: "All Artists",
-          route: ROUTES.ALL_ARTISTS,
-          active: true,
-        },
-      ]);
-
-      navigation.events.bindAllArtistsEvents();
+      grid.innerHTML = sections.join("");
+      return grid.closest("#" + IDS.dynamicContent) || grid;
     },
   },
 
   events: {
-    bindArtistPageEvents: function (artistData) {
-      const playButton = document.querySelector("#artistPlay");
-      if (playButton) {
-        playButton.addEventListener("click", function () {
-          navigation.actions.playArtistSongs(artistData);
-        });
-      }
-
-      const followButton = document.querySelector("#artistFollow");
-      if (followButton) {
-        const isFavorite = appState.favorites.has("artists", artistData.artist);
-        followButton.textContent = isFavorite ? "Unfavorite" : "Favorite";
-        followButton.classList.toggle(CLASSES.active, isFavorite);
-        followButton.addEventListener("click", function () {
-          const wasFavorite = appState.favorites.toggle("artists", artistData.artist);
-          followButton.textContent = wasFavorite ? "Unfavorite" : "Favorite";
-          followButton.classList.toggle(CLASSES.active, wasFavorite);
-        });
-      }
-
-      document.addEventListener("click", function (e) {
-        const playAlbumBtn = e.target.closest(".play-album");
-        if (playAlbumBtn) {
-          e.stopPropagation();
-          const activeTab = document.querySelector(".album-tab.active");
-          if (activeTab) {
-            const albumIndex = parseInt(activeTab.dataset.albumIndex);
-            const album = artistData.albums[albumIndex];
-            if (album) navigation.actions.playAlbumSongs(album, artistData.artist);
-          }
-        }
-      });
-    },
-
-    bindAlbumSwitcher: function (artistData) {
-      const albumTabs = document.querySelectorAll(".album-tab");
-      albumTabs.forEach(function (tab) {
-        tab.addEventListener("click", function (e) {
-          e.preventDefault();
-          const albumIndex = parseInt(tab.dataset.albumIndex);
-
-          albumTabs.forEach(function (t) {
-            t.classList.remove("active", "bg-accent-primary", "text-white");
-            t.classList.add("bg-gray-700", "text-gray-300");
-          });
-
-          tab.classList.add("active", "bg-accent-primary", "text-white");
-          tab.classList.remove("bg-gray-700", "text-gray-300");
-
-          navigation.rendering.displaySingleAlbum(artistData, albumIndex);
-        });
-      });
-    },
-
-    bindAllArtistsEvents: function () {
-      const artistSearch = $byId(IDS.artistSearch);
-      if (artistSearch) {
-        artistSearch.addEventListener("input", function (e) {
-          const query = e.target.value.toLowerCase().trim();
-          document.querySelectorAll(".artist-card").forEach(function (card) {
-            const artistName = card.querySelector("h3").textContent.toLowerCase();
-            const genreTag = card.querySelector(".genre-tag")?.textContent.toLowerCase() || "";
-            const matches = artistName.includes(query) || genreTag.includes(query);
-            card.parentElement.style.display = matches ? "block" : "none";
-          });
-        });
-      }
-
-      const genreFilters = $byId(IDS.genreFilters);
-      if (genreFilters && window.music) {
-        const genres = new Set();
-        window.music.forEach(function (artist) {
-          if (artist.genre) genres.add(artist.genre);
-        });
-
-        genreFilters.innerHTML = "";
-        Array.from(genres)
-          .sort()
-          .forEach(function (genre) {
-            const genreBtn = document.createElement("button");
-            genreBtn.className = "px-3 py-1 text-xs font-medium rounded-full bg-bg-subtle hover:bg-bg-muted transition-colors";
-            genreBtn.textContent = genre;
-
-            genreBtn.addEventListener("click", function () {
-              genreBtn.classList.toggle(CLASSES.active);
-              genreBtn.classList.toggle("bg-accent-primary");
-              genreBtn.classList.toggle("text-white");
-
-              const activeFilters = Array.from(genreFilters.querySelectorAll("." + CLASSES.active)).map(function (btn) {
-                return btn.textContent.toLowerCase();
-              });
-
-              document.querySelectorAll(".artist-card").forEach(function (card) {
-                const cardGenre = card.querySelector(".genre-tag")?.textContent.toLowerCase() || "";
-                card.parentElement.style.display = activeFilters.length === 0 || activeFilters.includes(cardGenre) ? "block" : "none";
-              });
-            });
-
-            genreFilters.appendChild(genreBtn);
-          });
-      }
-    },
-
-    bindSongItemEvents: function (container) {
+    bindViewInteractions(root, context) {
+      if (!root) return;
+      const container = root.closest("#" + IDS.dynamicContent) || root;
       if (!container) return;
 
-      container.querySelectorAll(".song-item").forEach(function (songItem, itemIndex) {
-        let clickCount = 0;
-        let clickTimer = null;
+      if (container._viewInteractionHandler) {
+        container.removeEventListener("click", container._viewInteractionHandler);
+      }
 
-        // Get the song data from the container's stored array
-        const songsContainer = songItem.closest(".songs-container");
-        const songIndex = parseInt(songItem.dataset.index);
-
-        // Store song data in memory, not in HTML
-        if (!songsContainer._songsData) {
-          songsContainer._songsData = [];
+      const handler = (event) => {
+        const sectionAction = event.target.closest("[data-section-action]");
+        if (sectionAction) {
+          event.preventDefault();
+          navigation.events.handleSectionAction(sectionAction.dataset.sectionAction, context);
+          return;
         }
 
-        songItem.addEventListener("click", function (e) {
-          if (e.target.closest(".song-actions") || e.target.closest("[data-action]")) return;
+        const actionButton = event.target.closest("[data-action]");
+        if (actionButton) {
+          event.preventDefault();
+          const card = actionButton.closest(".bento-card");
+          const payload = navigation.events.parseCardPayload(card);
+          navigation.actions.handleCardAction(actionButton.dataset.action, payload, context);
+          return;
+        }
 
-          clickCount++;
-          if (clickCount === 1) {
-            clickTimer = setTimeout(function () {
-              clickCount = 0;
-            }, 300);
-          } else if (clickCount === 2) {
-            clearTimeout(clickTimer);
-            clickCount = 0;
+        const card = event.target.closest(".bento-card");
+        if (card) {
+          const payload = navigation.events.parseCardPayload(card);
+          navigation.actions.handleCardTap(card, payload, context);
+        }
+      };
 
-            // Get song data from memory instead of parsing JSON
-            const songData = songsContainer._songsData[songIndex];
-            if (songData) {
-              musicPlayer.ui.playSong(songData);
-            }
+      container.addEventListener("click", handler);
+      container._viewInteractionHandler = handler;
+    },
+
+    handleSectionAction(action, context) {
+      switch (action) {
+        case "go-home":
+          appState.router?.navigateTo(ROUTES.HOME);
+          break;
+        case "artist-play":
+          navigation.actions.playArtistSongs(context?.artist);
+          break;
+        case "artist-shuffle":
+          navigation.actions.shuffleArtistSongs(context?.artist);
+          break;
+        case "artist-favorite":
+          if (context?.artist) {
+            appState.favorites.toggle("artists", context.artist.artist);
           }
-        });
+          break;
+        case "artist-queue":
+          navigation.actions.queueArtistSongs(context?.artist);
+          break;
+        case "album-play":
+          navigation.actions.playAlbumSongs(context?.album, context?.artist?.artist);
+          break;
+        case "album-queue":
+          navigation.actions.queueAlbumSongs(context?.album, context?.artist?.artist);
+          break;
+        case "album-favorite":
+          if (context?.album) {
+            appState.favorites.toggle("albums", context.album.album);
+          }
+          break;
+        case "playlist-play":
+          navigation.actions.playPlaylist(context?.playlist);
+          break;
+        case "playlist-queue":
+          navigation.actions.queuePlaylist(context?.playlist);
+          break;
+        case "playlist-delete":
+          navigation.actions.deletePlaylist(context?.playlist);
+          break;
+        case "playlist-browse":
+          appState.router?.navigateTo(ROUTES.HOME);
+          break;
+        default:
+          break;
+      }
+    },
 
-        const playButton = songItem.querySelector("[data-action='play']");
-        if (playButton) {
-          playButton.addEventListener("click", function (e) {
-            e.stopPropagation();
-            const songData = songsContainer._songsData[songIndex];
-            if (songData) {
-              musicPlayer.ui.playSong(songData);
-            }
-          });
-        }
-
-        const artistElement = songItem.querySelector("[data-artist]");
-        if (artistElement) {
-          artistElement.addEventListener("click", function (e) {
-            e.stopPropagation();
-            const artistName = artistElement.dataset.artist;
-            appState.router.navigateToArtist(artistName);
-          });
-        }
-
-        songItem.querySelectorAll("[data-action]").forEach(function (actionBtn) {
-          actionBtn.addEventListener("click", function (e) {
-            e.stopPropagation();
-            const action = actionBtn.dataset.action;
-            const songData = JSON.parse(songItem.dataset.song);
-            const context = songItem.dataset.context || "base";
-
-            if (action === "more") {
-              navigation.actions.showMoreActionsPopover(actionBtn, songData, context);
-            } else {
-              navigation.actions.handleSongAction(action, songData, context);
-            }
-          });
-        });
-      });
+    parseCardPayload(card) {
+      if (!card) return null;
+      const payloadString = card.dataset.payload;
+      if (!payloadString) return null;
+      try {
+        return JSON.parse(payloadString);
+      } catch (error) {
+        return null;
+      }
     },
   },
 
   actions: {
-    playArtistSongs: function (artistData) {
-      const allSongs = [];
-      artistData.albums.forEach(function (album) {
-        album.songs.forEach(function (song) {
-          allSongs.push({
-            ...song,
-            artist: artistData.artist,
-            album: album.album,
-            cover: utils.getAlbumImageUrl(album.album),
-          });
-        });
-      });
+    playArtistSongs(artistData) {
+      if (!artistData) return;
+      const songs = renderingHelpers.collectArtistSongs(artistData);
+      if (!songs.length) return;
+      appState.queue.clear();
+      songs.slice(1).forEach((song) => appState.queue.add(song));
+      musicPlayer.ui.playSong(songs[0]);
+      notifications.show(`Playing ${artistData.artist}`, NOTIFICATION_TYPES.SUCCESS);
+    },
 
-      if (allSongs.length > 0) {
-        appState.queue.clear();
-        allSongs.slice(1).forEach(function (song) {
-          appState.queue.add(song);
-        });
-        musicPlayer.ui.playSong(allSongs[0]);
+    shuffleArtistSongs(artistData) {
+      if (!artistData) return;
+      const songs = renderingHelpers.collectArtistSongs(artistData);
+      if (!songs.length) return;
+      const shuffled = [...songs].sort(() => Math.random() - 0.5);
+      appState.queue.clear();
+      shuffled.slice(1).forEach((song) => appState.queue.add(song));
+      musicPlayer.ui.playSong(shuffled[0]);
+      notifications.show(`Shuffling ${artistData.artist}`, NOTIFICATION_TYPES.SUCCESS);
+    },
+
+    queueArtistSongs(artistData) {
+      if (!artistData) return;
+      const songs = renderingHelpers.collectArtistSongs(artistData);
+      songs.forEach((song) => appState.queue.add(song));
+      notifications.show(`Queued ${songs.length} songs from ${artistData.artist}`, NOTIFICATION_TYPES.INFO);
+    },
+
+    playAlbumSongs(album, artistName) {
+      if (!album || !ensureArray(album.songs).length) return;
+      const cover = utils.getAlbumImageUrl(album.album);
+      const enriched = ensureArray(album.songs).map((song) => ({
+        ...song,
+        artist: artistName,
+        album: album.album,
+        cover,
+      }));
+      appState.queue.clear();
+      enriched.slice(1).forEach((song) => appState.queue.add(song));
+      musicPlayer.ui.playSong(enriched[0]);
+    },
+
+    queueAlbumSongs(album, artistName) {
+      if (!album || !ensureArray(album.songs).length) return;
+      ensureArray(album.songs).forEach((song) =>
+        appState.queue.add({ ...song, artist: artistName, album: album.album, cover: utils.getAlbumImageUrl(album.album) })
+      );
+      notifications.show(`Queued ${album.album}`, NOTIFICATION_TYPES.SUCCESS);
+    },
+
+    playPlaylist(playlist) {
+      if (!playlist || !playlist.songs.length) return;
+      appState.queue.clear();
+      playlist.songs.slice(1).forEach((song) => appState.queue.add(song));
+      musicPlayer.ui.playSong(playlist.songs[0]);
+    },
+
+    queuePlaylist(playlist) {
+      if (!playlist) return;
+      playlist.songs.forEach((song) => appState.queue.add(song));
+      notifications.show(`Queued ${playlist.name}`, NOTIFICATION_TYPES.INFO);
+    },
+
+    async deletePlaylist(playlist) {
+      if (!playlist) return;
+      const confirmed = await overlays.dialog.confirm(`Delete ${playlist.name}?`, { okText: "Delete" });
+      if (confirmed) {
+        await playlists.remove(playlist.id);
+        appState.router?.navigateTo(ROUTES.HOME);
       }
     },
 
-    playAlbumSongs: function (album, artistName) {
-      if (album.songs.length === 0) return;
-
-      appState.queue.clear();
-      album.songs.slice(1).forEach(function (song) {
-        appState.queue.add({
-          ...song,
-          artist: artistName,
-          album: album.album,
-          cover: utils.getAlbumImageUrl(album.album),
-        });
-      });
-
-      musicPlayer.ui.playSong({
-        ...album.songs[0],
-        artist: artistName,
-        album: album.album,
-        cover: utils.getAlbumImageUrl(album.album),
-      });
+    handleCardTap(card, payload, context) {
+      const type = card?.dataset.cardType;
+      switch (type) {
+        case "artist":
+          if (payload?.artist) {
+            appState.router?.navigateTo(ROUTES.ARTIST, { artist: payload.artist });
+          }
+          break;
+        case "album":
+          if (payload?.artist && payload?.album) {
+            appState.router?.navigateTo(ROUTES.ALBUM, { artist: payload.artist, album: payload.album });
+          }
+          break;
+        case "playlist":
+          if (payload?.id) {
+            playlists.show(payload.id);
+          }
+          break;
+        case "song":
+          if (payload) {
+            musicPlayer.ui.playSong(payload);
+          }
+          break;
+        default:
+          break;
+      }
     },
 
-    handleSongAction: function (action, songData, context) {
+    handleCardAction(action, payload, context) {
+      switch (action) {
+        case "play-artist":
+          navigation.actions.playArtistSongs(renderingHelpers.findArtist(payload?.artist || payload?.name));
+          break;
+        case "view-artist":
+          if (payload?.artist) appState.router?.navigateTo(ROUTES.ARTIST, { artist: payload.artist });
+          break;
+        case "favorite-artist":
+          if (payload?.artist) appState.favorites.toggle("artists", payload.artist);
+          break;
+        case "play-album":
+          navigation.actions.playAlbumSongs(payload, payload?.artist);
+          break;
+        case "view-album":
+          if (payload?.artist && payload?.album) appState.router?.navigateTo(ROUTES.ALBUM, { artist: payload.artist, album: payload.album });
+          break;
+        case "favorite-album":
+          if (payload?.album) appState.favorites.toggle("albums", payload.album);
+          break;
+        case "play-song":
+          if (payload) musicPlayer.ui.playSong(payload);
+          break;
+        case "queue-song":
+          if (payload) {
+            appState.queue.add(payload);
+            notifications.show(`Queued ${payload.title}`, NOTIFICATION_TYPES.SUCCESS);
+          }
+          break;
+        case "favorite-song":
+          if (payload?.id) appState.favorites.toggle("songs", payload.id);
+          break;
+        case "play-playlist":
+          navigation.actions.playPlaylist(payload);
+          break;
+        case "view-playlist":
+          if (payload?.id) playlists.show(payload.id);
+          break;
+        case "favorite-playlist":
+          notifications.show("Playlist favorites coming soon", NOTIFICATION_TYPES.INFO);
+          break;
+        default:
+          navigation.actions.handleSongAction(action, payload, context);
+          break;
+      }
+    },
+
+    handleSongAction(action, songData, context) {
+      if (!songData) return;
       switch (action) {
         case "favorite":
-          const wasFavorite = appState.favorites.toggle("songs", songData.id);
-          const message = wasFavorite ? 'Added "' + songData.title + '" to your favorite music' : 'Removed "' + songData.title + '" from your favorite music';
-          notifications.show(message, wasFavorite ? NOTIFICATION_TYPES.SUCCESS : NOTIFICATION_TYPES.INFO);
+        case "favorite-song":
+          appState.favorites.toggle("songs", songData.id);
           break;
-
         case "play-next":
           appState.queue.add(songData, 0);
-          notifications.show('"' + songData.title + '" will play next', NOTIFICATION_TYPES.SUCCESS);
+          notifications.show(`"${songData.title}" will play next`, NOTIFICATION_TYPES.SUCCESS);
           break;
-
         case "add-queue":
+        case "queue-song":
           appState.queue.add(songData);
-          notifications.show('Added "' + songData.title + '" to queue', NOTIFICATION_TYPES.SUCCESS);
+          notifications.show(`Added "${songData.title}" to queue`, NOTIFICATION_TYPES.SUCCESS);
           break;
-
         case "add-playlist":
           navigation.actions.showPlaylistSelector(songData);
           break;
-
-        case "remove-from-playlist":
-          const playlistContainer = document.querySelector("[data-playlist-id]");
-          if (playlistContainer) {
-            const playlistId = playlistContainer.dataset.playlistId;
-            if (playlists.removeSong(playlistId, songData.id)) {
-              playlists.show(playlistId);
-              notifications.show('Removed "' + songData.title + '" from playlist', NOTIFICATION_TYPES.INFO);
-            }
-          }
-          break;
-
         case "download":
           notifications.show("Download feature coming soon", NOTIFICATION_TYPES.INFO);
           break;
-
         case "share":
           navigation.actions.shareSong(songData);
           break;
-
         case "view-artist":
-          appState.router.navigateToArtist(songData.artist);
+          appState.router.navigateTo(ROUTES.ARTIST, { artist: songData.artist });
           break;
-
         default:
+          break;
       }
     },
 
-    showMoreActionsPopover: function (triggerButton, songData, context) {
-      document.querySelectorAll(".more-actions-popover").forEach(function (p) {
-        p.remove();
-      });
-
-      const popover = document.createElement("div");
-      popover.className = "more-actions-popover";
-
-      popover.innerHTML = render.actionPopover(ACTION_GRID_ITEMS);
-
-      document.body.appendChild(popover);
-
-      const viewport = {
-        width: window.innerWidth,
-        height: window.innerHeight,
-      };
-
-      const triggerRect = triggerButton.getBoundingClientRect();
-      const popoverRect = popover.getBoundingClientRect();
-
-      let left = triggerRect.right + 8;
-      let top = triggerRect.top;
-
-      if (left + popoverRect.width > viewport.width - 16) {
-        left = triggerRect.left - popoverRect.width - 8;
-        if (left < 16) {
-          left = Math.max(16, Math.min(viewport.width - popoverRect.width - 16, triggerRect.left + (triggerRect.width - popoverRect.width) / 2));
-        }
-      }
-
-      if (top + popoverRect.height > viewport.height - 16) {
-        top = Math.max(16, viewport.height - popoverRect.height - 16);
-      }
-
-      top = Math.max(16, top);
-
-      popover.style.left = left + "px";
-      popover.style.top = top + "px";
-
-      popover.querySelectorAll(".popover-action-btn").forEach(function (btn) {
-        btn.addEventListener("click", function (e) {
-          e.stopPropagation();
-          const action = btn.dataset.action;
-          popover.remove();
-          navigation.actions.handleSongAction(action, songData, context);
-        });
-      });
-
-      const closePopover = function (e) {
-        if (!popover.contains(e.target) && !triggerButton.contains(e.target)) {
-          popover.remove();
-          document.removeEventListener("click", closePopover);
-          document.removeEventListener("keydown", escapeHandler);
-        }
-      };
-
-      const escapeHandler = function (e) {
-        if (e.key === "Escape") {
-          popover.remove();
-          document.removeEventListener("click", closePopover);
-          document.removeEventListener("keydown", escapeHandler);
-        }
-      };
-
-      setTimeout(function () {
-        document.addEventListener("click", closePopover);
-        document.addEventListener("keydown", escapeHandler);
-      }, 100);
-    },
-
-    showPlaylistSelector: function (songData) {
+    showPlaylistSelector(songData) {
       if (appState.playlists.length === 0) {
-        overlays.dialog.confirm("No playlists found. Create a new playlist?", { okText: "Create Playlist", cancelText: "Cancel" }).then(function (confirmed) {
-          if (confirmed) {
-            playlists.create().then(function (playlist) {
-              if (playlist) {
-                playlists.addSong(playlist.id, songData);
-              }
-            });
-          }
-        });
+        overlays.dialog
+          .confirm("No playlists found. Create a new playlist?", { okText: "Create Playlist", cancelText: "Cancel" })
+          .then((confirmed) => {
+            if (confirmed) {
+              playlists.create().then((playlist) => {
+                if (playlist) {
+                  playlists.addSong(playlist.id, songData);
+                }
+              });
+            }
+          });
         return;
       }
 
       const playlistOptions = appState.playlists
-        .map(function (playlist) {
+        .map((playlist) => {
           return `
         <button class="playlist-option" data-playlist-id="${playlist.id}">
           <div class="playlist-icon">
@@ -1078,15 +1347,15 @@ export const navigation = {
 
       const modal = document.getElementById("playlist-selector");
 
-      modal.querySelectorAll(".playlist-option").forEach(function (option) {
-        option.addEventListener("click", function () {
+      modal.querySelectorAll(".playlist-option").forEach((option) => {
+        option.addEventListener("click", () => {
           const playlistId = option.dataset.playlistId;
           playlists.addSong(playlistId, songData);
           overlays.close("playlist-selector");
         });
       });
 
-      modal.querySelector(".create-new-playlist").addEventListener("click", async function () {
+      modal.querySelector(".create-new-playlist").addEventListener("click", async () => {
         overlays.close("playlist-selector");
         const newPlaylist = await playlists.create();
         if (newPlaylist) {
@@ -1094,20 +1363,20 @@ export const navigation = {
         }
       });
 
-      modal.querySelector(".cancel-playlist-selection").addEventListener("click", function () {
+      modal.querySelector(".cancel-playlist-selection").addEventListener("click", () => {
         overlays.close("playlist-selector");
       });
     },
 
-    shareSong: function (songData) {
+    shareSong(songData) {
       if (navigator.share) {
         navigator
           .share({
             title: songData.title,
-            text: 'Listen to "' + songData.title + '" by ' + songData.artist,
+            text: `Listen to "${songData.title}" by ${songData.artist}`,
             url: window.location.href,
           })
-          .catch(function () {
+          .catch(() => {
             navigation.actions.fallbackShare(songData);
           });
       } else {
@@ -1115,15 +1384,15 @@ export const navigation = {
       }
     },
 
-    fallbackShare: function (songData) {
+    fallbackShare() {
       const shareUrl = window.location.href;
       if (navigator.clipboard) {
         navigator.clipboard
           .writeText(shareUrl)
-          .then(function () {
+          .then(() => {
             notifications.show("Song link copied to clipboard!", NOTIFICATION_TYPES.SUCCESS);
           })
-          .catch(function () {
+          .catch(() => {
             notifications.show("Share feature not available", NOTIFICATION_TYPES.WARNING);
           });
       } else {

--- a/siteScripts/pages/router.js
+++ b/siteScripts/pages/router.js
@@ -84,13 +84,11 @@ export const deepLinkRouter = {
     const decodedArtist = artistName;
     const decodedAlbum = albumName;
 
-    if (window.appState?.router && window.music) {
-      const artistData = window.music.find(a => a.artist === decodedArtist);
-      if (artistData && window.navigation?.pages?.loadArtistPage) {
-        window.navigation.pages.loadArtistPage(artistData, decodedAlbum);
-      } else {
-        this.navigateToHome();
-      }
+    if (window.appState?.router) {
+      window.appState.router.navigateTo(window.ROUTES?.ALBUM || 'album', {
+        artist: decodedArtist,
+        album: decodedAlbum,
+      });
     }
   },
 

--- a/siteScripts/pages/statics.js
+++ b/siteScripts/pages/statics.js
@@ -11,8 +11,48 @@ import {
 
 import { ui } from './updates.js';
 import { render } from '../utilities/templates.js';
+import { BentoCards } from '../components/bentoCards.js';
+import { ROUTES } from '../map.js';
 
 export const homePage = {
+  sections: [
+    {
+      id: 'home-recent',
+      title: 'Recently played',
+      description: 'Jump back into the tracks you loved last time you were here.',
+      containerId: IDS.recentlyPlayedSection,
+      action: { label: 'Open queue', action: 'open-recent-tab' },
+    },
+    {
+      id: 'home-albums',
+      title: 'Discover albums',
+      description: 'Albums we think you will enjoy based on your recent plays.',
+      containerId: IDS.randomAlbumsSection,
+      action: { label: 'All artists', action: 'goto-artists' },
+    },
+    {
+      id: 'home-artists',
+      title: 'Favorite artists',
+      description: 'Your saved artists plus a few mood-matching recommendations.',
+      containerId: IDS.favoriteArtistsSection,
+      action: { label: 'Manage favorites', action: 'view-favorite-artists' },
+    },
+    {
+      id: 'home-playlists',
+      title: 'Your playlists',
+      description: 'Keep curating the perfect soundtrack for every moment.',
+      containerId: IDS.playlistsSection,
+      action: { label: 'New playlist', action: 'create-playlist' },
+    },
+    {
+      id: 'home-favorites',
+      title: 'Favorite songs',
+      description: "The songs you can't live without – ready in one tap.",
+      containerId: IDS.favoriteSongsSection,
+      action: { label: 'View favorites', action: 'view-favorite-songs' },
+    },
+  ],
+
   initialize: () => {
     appState.homePageManager = {
       renderHomePage: homePage.render,
@@ -23,779 +63,376 @@ export const homePage = {
     const dynamicContent = $byId(IDS.dynamicContent);
     if (!dynamicContent) return;
 
-    dynamicContent.innerHTML = "";
-    dynamicContent.innerHTML = render.page("home_bento", { IDS: window.IDS });
+    const heroSubtitle = homePage.getHeroSubtitle();
+    dynamicContent.innerHTML = render.viewShell({
+      viewId: 'home-view',
+      accentLabel: 'Now streaming',
+      title: 'Your personal music universe',
+      subtitle: heroSubtitle,
+      actions: [
+        { label: 'Shuffle library', action: 'shuffle-library' },
+        { label: 'Browse artists', action: 'goto-artists' },
+      ],
+    });
 
-    homePage.addStyles();
+    const viewGrid = dynamicContent.querySelector('[data-view-grid]');
+    if (!viewGrid) return;
 
-    setTimeout(() => homePage.renderRecentlyPlayed(), 100);
-    setTimeout(() => homePage.renderRandomAlbums(), 300);
-    setTimeout(() => homePage.renderFavoriteArtists(), 500);
-    setTimeout(() => homePage.renderPlaylists(), 700);
-    setTimeout(() => homePage.renderFavoriteSongs(), 900);
+    viewGrid.innerHTML = homePage.sections
+      .map((section) => homePage.renderSectionShell(section))
+      .join('');
 
+    homePage.renderRecentlyPlayed();
+    homePage.renderRandomAlbums();
+    homePage.renderFavoriteArtists();
+    homePage.renderPlaylists();
+    homePage.renderFavoriteSongs();
     homePage.bindEvents();
   },
 
-  addStyles: () => {
-    if ($byId("bento-grid-styles")) return;
+  renderSectionShell: (section) => {
+    const actionHtml = section.action
+      ? `<div class="view-section-actions"><button type="button" data-section-action="${section.action.action}" data-section-id="${section.id}">${section.action.label}</button></div>`
+      : '';
 
-    const styleEl = document.createElement("style");
-    styleEl.id = "bento-grid-styles";
-    styleEl.textContent = `
-      .bento-grid {
-        display: grid;
-        gap: 1.5rem;
-      }
-      
-      .bento-card {
-        border-radius: 1rem;
-        padding: 1.5rem;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        backdrop-filter: blur(10px);
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-      
-      .bento-card:hover {
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-      }
-      
-      .card-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 1rem;
-        padding-bottom: 0.5rem;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-      }
-      
-      .card-content {
-        min-height: 200px;
-      }
-      
-      .skeleton-loader {
-        height: 200px;
-        background: linear-gradient(90deg, rgba(255,255,255,0.05) 25%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.05) 75%);
-        background-size: 200% 100%;
-        animation: loading 1.5s infinite;
-        border-radius: 0.5rem;
-      }
-      
-      @keyframes loading {
-        0% { background-position: 200% 0; }
-        100% { background-position: -200% 0; }
-      }
-      
-      /* Updated styles from templates.js for .modern-track-item */
-      .modern-track-item, .modern-favorite-item, .modern-playlist-card {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        padding: 0.5rem;
-        border-radius: 0.5rem;
-        background: rgba(255, 255, 255, 0.05);
-        cursor: pointer;
-        transition: all 0.2s ease;
-        position: relative;
-      }
-      
-      .modern-track-item:hover, .modern-favorite-item:hover, .modern-playlist-card:hover {
-        background: rgba(255, 255, 255, 0.1);
-        transform: translateY(-2px);
-      }
-
-      .track-artwork-container, .favorite-artwork-container, .playlist-artwork-container, .artist-artwork-container {
-        width: 40px;
-        height: 40px;
-        border-radius: 0.25rem;
-        flex-shrink: 0;
-        position: relative;
-        overflow: hidden;
-      }
-
-      .track-artwork, .favorite-artwork, .artist-avatar-image {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
-      .playlist-icon-wrapper {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background-color: rgba(96, 165, 250, 0.3); /* Example color */
-      }
-
-      .track-content, .favorite-content, .playlist-content, .artist-content {
-        flex: 1;
-        min-width: 0;
-      }
-
-      .track-title-text, .favorite-title-text, .playlist-name-text, .artist-name-text {
-        font-weight: 500;
-        margin-bottom: 0.125rem;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      
-      .track-artist-text, .favorite-artist-text, .playlist-tracks-text, .artist-label {
-        font-size: 0.875rem;
-        color: rgba(255, 255, 255, 0.7);
-        cursor: pointer;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .track-artist-text:hover, .favorite-artist-text:hover {
-        color: rgba(255, 255, 255, 0.9);
-        text-decoration: underline;
-      }
-      
-      .album-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 1rem;
-      }
-      
-      .album-card {
-        text-align: center;
-        cursor: pointer;
-        transition: transform 0.2s ease;
-        position: relative;
-      }
-      
-      .album-cover {
-        width: 100%;
-        aspect-ratio: 1;
-        border-radius: 0.5rem;
-        object-fit: cover;
-        margin-bottom: 0.5rem;
-        position: relative;
-      }
-      
-      .album-overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.6);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        transition: opacity 0.2s ease;
-        border-radius: 0.5rem;
-        margin-bottom: 0.5rem;
-      }
-      
-      .album-card:hover .album-overlay {
-        opacity: 1;
-      }
-      
-      .album-play-btn {
-        width: 3rem;
-        height: 3rem;
-        background: rgba(59, 130, 246, 0.9);
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        border: none;
-        cursor: pointer;
-        transition: all 0.2s ease;
-      }
-      
-      .album-play-btn:hover {
-        transform: scale(1.1);
-        background: rgba(59, 130, 246, 1);
-      }
-      
-      .album-play-btn svg {
-        width: 1.2rem;
-        height: 1.2rem;
-      }
-      
-      .album-info {
-        font-size: 0.875rem;
-      }
-      
-      .album-title {
-        font-weight: 500;
-        margin-bottom: 0.125rem;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      
-      .album-artist {
-        color: rgba(255, 255, 255, 0.7);
-        cursor: pointer;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      
-      .album-artist:hover {
-        color: rgba(255, 255, 255, 0.9);
-        text-decoration: underline;
-      }
-      
-      /* Style for .modern-artist-card */
-      .modern-artist-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        gap: 1rem;
-      }
-      
-      .modern-artist-card {
-        text-align: center;
-        cursor: pointer;
-        transition: transform 0.2s ease;
-        position: relative;
-      }
-      
-      .modern-artist-card:hover {
-        transform: scale(1.05);
-      }
-      
-      .artist-avatar-image {
-        border-radius: 50%;
-        width: 100%;
-        aspect-ratio: 1;
-        object-fit: cover;
-      }
-      
-      .artist-name-text {
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-top: 0.5rem;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      
-      .create-playlist-btn {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.75rem;
-        border-radius: 0.5rem;
-        background: rgba(59, 130, 246, 0.1);
-        border: 1px dashed rgba(59, 130, 246, 0.3);
-        color: rgb(59, 130, 246);
-        cursor: pointer;
-        transition: all 0.2s ease;
-        width: 100%;
-        margin-top: 0.5rem;
-        text-align: center;
-        justify-content: center;
-      }
-      
-      .create-playlist-btn:hover {
-        background: rgba(59, 130, 246, 0.2);
-        border-color: rgba(59, 130, 246, 0.5);
-        transform: translateY(-1px);
-      }
-      
-      .empty-state {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-        color: rgba(255, 255, 255, 0.5);
-        font-size: 0.875rem;
-        text-align: center;
-        padding: 2rem 1rem;
-      }
-      
-      .empty-state svg {
-        margin-bottom: 1rem;
-        opacity: 0.6;
-      }
-      
-      /* --- ENHANCEMENT: Styles for Track, Playlist, and Favorite Song overlays --- */
-      .track-play-overlay, .playlist-play-overlay, .favorite-play-overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.5);
-        backdrop-filter: blur(4px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        transform: scale(0.95);
-        transition: opacity 0.2s ease, transform 0.2s ease;
-        border-radius: 0.25rem;
-        cursor: pointer;
-      }
-      
-      .modern-track-item:hover .track-play-overlay,
-      .modern-playlist-card:hover .playlist-play-overlay,
-      .modern-favorite-item:hover .favorite-play-overlay {
-        opacity: 1;
-        transform: scale(1);
-      }
-
-      /* --- REVERT: Original styles for Artist overlay --- */
-      .artist-play-overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.6); /* Original background */
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        transition: opacity 0.2s ease; /* Original transition */
-        border-radius: 50%;
-        cursor: pointer;
-      }
-
-      .modern-artist-card:hover .artist-play-overlay {
-        opacity: 1;
-      }
-      /* --- END REVERT --- */
-
-
-      .artist-artwork-container {
-        border-radius: 50%;
-      }
-
-      /* --- ENHANCEMENT: New styles for Track, Playlist, and Favorite Song buttons --- */
-      .track-play-btn, .playlist-play-btn, .favorite-play-btn {
-        width: 2.5rem; /* 40px */
-        height: 2.5rem; /* 40px */
-        background: rgba(59, 130, 246, 0.9); /* Blue */
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        border: none;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        transform: scale(1);
-      }
-
-      .track-play-btn:hover, .playlist-play-btn:hover, .favorite-play-btn:hover {
-        transform: scale(1.1);
-        background: rgba(59, 130, 246, 1);
-      }
-
-      .track-play-btn svg, .playlist-play-btn svg, .favorite-play-btn svg {
-        width: 1.125rem; /* 18px */
-        height: 1.125rem; /* 18px */
-        margin-left: 2px; /* Optical centering */
-      }
-      
-      /* --- REVERT: Original styles for Artist play button --- */
-      .artist-play-btn {
-        color: white;
-        border: none;
-        background: none;
-        cursor: pointer;
-        padding: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 2.5rem; /* 40px */
-        height: 2.5rem; /* 40px */
-        transition: transform 0.2s ease;
-      }
-      
-      .artist-play-btn svg {
-         width: 1.5rem; /* 24px */
-         height: 1.5rem; /* 24px */
-      }
-      
-      .artist-play-btn:hover {
-        transform: scale(1.1);
-      }
-      /* --- END REVERT --- */
-      
-      .animate-fade-in {
-        animation: fadeIn 0.3s ease-in;
-      }
-      
-      @keyframes fadeIn {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-      }
+    return `
+      <div class="view-section" data-section-id="${section.id}">
+        <div class="view-section-header">
+          <div>
+            <h2>${section.title}</h2>
+            ${section.description ? `<p class="view-section-description">${section.description}</p>` : ''}
+          </div>
+          ${actionHtml}
+        </div>
+        <div class="bento-grid" id="${section.containerId}"></div>
+      </div>
     `;
-    document.head.appendChild(styleEl);
+  },
+
+  getSectionContainer: (containerId) => {
+    return $byId(containerId);
   },
 
   renderRecentlyPlayed: () => {
-    const container = $byId(IDS.recentlyPlayedSection);
+    const container = homePage.getSectionContainer(IDS.recentlyPlayedSection);
     if (!container) return;
 
-    if (!appState.recentlyPlayed || appState.recentlyPlayed.length === 0) {
-      container.innerHTML = homePage.renderEmptyState("No recently played tracks", "music-note");
+    const tracks = homePage.getRecentSongs(6);
+    if (!tracks.length) {
+      container.innerHTML = homePage.renderEmptyState('No recently played songs', 'Play something new and it will show up here.');
       return;
     }
 
-    const recentTracks = appState.recentlyPlayed.slice(0, 5);
-    container.innerHTML = render.homeSection.recentlyPlayed(recentTracks, utils);
+    const cards = tracks.map((song, index) => ({
+      type: 'song',
+      data: {
+        title: song.title,
+        album: song.album,
+        artist: song.artist,
+        duration: song.duration || '0:00',
+        cover: song.cover,
+        trackNumber: index + 1,
+        payload: song,
+      },
+    }));
 
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".modern-track-item").forEach((track) => {
-      track.addEventListener("click", (e) => {
-        // *** UPDATED CLASS ***
-        if (e.target.closest(".track-artist-text") || e.target.closest(".track-action-btn")) return; // Also ignore other buttons
-
-        try {
-          const songData = JSON.parse(track.dataset.song);
-          musicPlayer.ui.playSong(songData);
-        } catch (error) {}
-      });
-    });
-
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".track-artist-text").forEach((artistEl) => {
-      artistEl.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const artistName = artistEl.dataset.artist;
-        if (appState.router) {
-          appState.router.navigateTo(ROUTES.ARTIST, {
-            artist: artistName,
-          });
-        }
-      });
-    });
+    container.innerHTML = BentoCards.renderCollection(cards);
   },
 
   renderRandomAlbums: () => {
-    const container = $byId(IDS.randomAlbumsSection);
+    const container = homePage.getSectionContainer(IDS.randomAlbumsSection);
     if (!container) return;
 
     const albums = homePage.getRandomAlbums(6);
-
-    if (!albums || albums.length === 0) {
-      container.innerHTML = homePage.renderEmptyState("No albums found", "album");
+    if (!albums.length) {
+      container.innerHTML = homePage.renderEmptyState('No albums found', 'Your library does not have enough albums yet.');
       return;
     }
 
-    container.innerHTML = render.homeSection.randomAlbums(albums, utils);
+    const cards = albums.map((album) => ({
+      type: 'album',
+      data: {
+        title: album.album,
+        artist: album.artist,
+        year: album.year || '—',
+        songCount: album.songs.length,
+        cover: album.cover,
+        payload: album,
+      },
+    }));
 
-    // This section's selectors were already correct!
-    container.querySelectorAll(".album-play-btn").forEach((playBtn) => {
-      playBtn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const artistName = playBtn.dataset.artist;
-        const albumName = playBtn.dataset.album;
-        homePage.playAlbum(artistName, albumName);
-      });
-    });
-
-    container.querySelectorAll(".album-card").forEach((albumCard) => {
-      albumCard.addEventListener("click", (e) => {
-        if (e.target.closest(".album-play-btn") || e.target.closest(".album-artist")) return;
-
-        const artistName = albumCard.dataset.artist;
-        const albumName = albumCard.dataset.album;
-        homePage.playAlbum(artistName, albumName);
-      });
-    });
-
-    container.querySelectorAll(".album-artist").forEach((artistEl) => {
-      artistEl.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const artistName = artistEl.dataset.artist;
-        const albumCard = artistEl.closest('.album-card');
-        const albumName = albumCard ? albumCard.dataset.album : null;
-        
-        if (appState.router) {
-          appState.router.navigateTo(ROUTES.ARTIST, {
-            artist: artistName,
-          });
-          
-          if (albumName) {
-            sessionStorage.setItem('pendingAlbumLoad', albumName);
-            
-            setTimeout(() => {
-              const storedAlbum = sessionStorage.getItem('pendingAlbumLoad');
-              if (storedAlbum === albumName) {
-                const artistData = window.music?.find((a) => a.artist === artistName);
-                if (artistData) {
-                  navigation.pages.loadArtistPage(artistData, albumName);
-                }
-                sessionStorage.removeItem('pendingAlbumLoad');
-              }
-            }, 100);
-          }
-        }
-      });
-    });
+    container.innerHTML = BentoCards.renderCollection(cards);
   },
 
   renderFavoriteArtists: () => {
-    const container = $byId(IDS.favoriteArtistsSection);
+    const container = homePage.getSectionContainer(IDS.favoriteArtistsSection);
     if (!container) return;
 
-    if (!appState.favorites.artists || appState.favorites.artists.size === 0) {
-      container.innerHTML = homePage.renderEmptyState("No favorite artists", "artist");
+    const artists = homePage.getFavoriteArtists(6);
+    if (!artists.length) {
+      container.innerHTML = homePage.renderEmptyState('No favorite artists', 'Tap the heart icon on an artist to favorite them.');
       return;
     }
 
-    const artists = Array.from(appState.favorites.artists).slice(0, 6);
-    container.innerHTML = render.homeSection.favoriteArtists(artists, utils);
+    const cards = artists.map((artist) => ({
+      type: 'artist',
+      data: {
+        name: artist.artist,
+        genre: artist.genre || 'Various',
+        statLine: `${artist.albums.length} albums`,
+        cover: artist.cover,
+        payload: { artist: artist.artist },
+      },
+    }));
 
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".modern-artist-card").forEach((artistEl) => {
-      artistEl.addEventListener("click", (e) => {
-        if (e.target.closest(".artist-action-btn")) return; // Ignore action buttons
-        const artistName = artistEl.dataset.artist;
-        if (appState.router) {
-          appState.router.navigateTo(ROUTES.ARTIST, {
-            artist: artistName,
-          });
-        }
-      });
-    });
+    container.innerHTML = BentoCards.renderCollection(cards);
   },
 
   renderPlaylists: () => {
-    const container = $byId(IDS.playlistsSection);
+    const container = homePage.getSectionContainer(IDS.playlistsSection);
     if (!container) return;
-
-    let html = "";
 
     if (!appState.playlists || appState.playlists.length === 0) {
-      html = homePage.renderEmptyState("No playlists yet", "playlist");
-    } else {
-      const displayPlaylists = appState.playlists.slice(0, 3);
-      html = render.homeSection.playlists(displayPlaylists);
-    }
-
-    html += `
-      <button class="create-playlist-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
-          <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-        </svg>
-        Create Playlist
-      </button>
-    `;
-
-    container.innerHTML = html;
-
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".modern-playlist-card").forEach((playlistEl) => {
-      playlistEl.addEventListener("click", (e) => {
-        if (e.target.closest(".playlist-action-btn")) return; // Ignore action buttons
-        const playlistId = playlistEl.dataset.playlistId;
-        playlists.show(playlistId);
+      container.innerHTML = homePage.renderEmptyState('No playlists yet', 'Create your first playlist to pin your vibe.', {
+        label: 'Create playlist',
+        action: 'create-playlist',
       });
-    });
-
-    const createBtn = container.querySelector(".create-playlist-btn");
-    if (createBtn) {
-      createBtn.addEventListener("click", () => {
-        playlists.create().then(newPlaylist => { // Wait for the async create to finish
-          if (newPlaylist) {
-            setTimeout(() => homePage.renderPlaylists(), 100); // Re-render if successful
-          }
-        });
-      });
-    }
-  },
-
-  renderFavoriteSongs: () => {
-    const container = $byId(IDS.favoriteSongsSection);
-    if (!container) return;
-
-    if (!appState.favorites.songs || appState.favorites.songs.size === 0) {
-      container.innerHTML = homePage.renderEmptyState("No favorite songs", "heart");
       return;
     }
 
-    const songs = homePage.getSongsByIds(Array.from(appState.favorites.songs).slice(0, 5));
-    container.innerHTML = render.homeSection.favoriteSongs(songs, utils);
-
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".modern-favorite-item").forEach((track) => {
-      track.addEventListener("click", (e) => {
-        // *** UPDATED CLASSES ***
-        if (e.target.closest(".favorite-artist-text") || e.target.closest(".favorite-action-btn")) return;
-
-        try {
-          const songData = JSON.parse(track.dataset.song);
-          musicPlayer.ui.playSong(songData);
-        } catch (error) {}
-      });
+    const playlistsToShow = appState.playlists.slice(0, 6);
+    const cards = playlistsToShow.map((playlist) => {
+      const cover = playlist.songs[0]
+        ? playlist.songs[0].cover || utils.getAlbumImageUrl(playlist.songs[0].album)
+        : utils.getDefaultAlbumImage();
+      return {
+        type: 'playlist',
+        data: {
+          name: playlist.name,
+          owner: 'You',
+          songCount: playlist.songs.length,
+          updatedLabel: new Date(playlist.created).toLocaleDateString(),
+          cover,
+          payload: playlist,
+        },
+      };
     });
 
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".favorite-artist-text").forEach((artistEl) => {
-      artistEl.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const artistName = artistEl.dataset.artist;
-        if (appState.router) {
-          appState.router.navigateTo(ROUTES.ARTIST, {
-            artist: artistName,
-          });
-        }
-      });
-    });
-
-    // *** UPDATED SELECTOR ***
-    container.querySelectorAll(".favorite-heart-btn").forEach((heartBtn) => {
-      heartBtn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const songId = heartBtn.dataset.songId;
-        appState.favorites.remove("songs", songId);
-
-        // *** UPDATED CLASS ***
-        const track = heartBtn.closest(".modern-favorite-item");
-        track.style.transition = "all 0.3s ease";
-        track.style.opacity = "0";
-        track.style.transform = "translateX(-20px)";
-
-        setTimeout(() => {
-          track.remove();
-          // *** UPDATED CLASS ***
-          const remaining = container.querySelectorAll(".modern-favorite-item");
-          if (remaining.length === 0) {
-            homePage.renderFavoriteSongs();
-          }
-        }, 300);
-      });
-    });
+    container.innerHTML = BentoCards.renderCollection(cards);
   },
 
-  bindEvents: () => {
-    document.querySelectorAll("[data-view]").forEach((link) => {
-      link.addEventListener("click", (e) => {
-        e.preventDefault();
-        const view = link.dataset.view;
+  renderFavoriteSongs: () => {
+    const container = homePage.getSectionContainer(IDS.favoriteSongsSection);
+    if (!container) return;
 
-        switch (view) {
-          case "recent":
-            musicPlayer.mainPlayer.open();
-            setTimeout(() => musicPlayer.mainPlayer.switchTab("recent"), 50);
-            break;
-          case "albums":
-            notifications.show("Albums view coming soon");
-            break;
-          case "favorite-artists":
-            views.showFavoriteArtists();
-            break;
-          case "playlists":
-            playlists.showAll();
-            break;
-          case "favorite-songs":
-            views.showFavoriteSongs();
-            break;
-          default:
-            notifications.show("View coming soon");
-        }
-      });
-    });
+    const songs = homePage.getFavoriteSongs(6);
+    if (!songs.length) {
+      container.innerHTML = homePage.renderEmptyState('No favorite songs', 'Add songs to your favorites to quick access them.');
+      return;
+    }
+
+    const cards = songs.map((song, index) => ({
+      type: 'song',
+      data: {
+        title: song.title,
+        artist: song.artist,
+        album: song.album,
+        duration: song.duration || '0:00',
+        cover: song.cover,
+        trackNumber: index + 1,
+        payload: song,
+      },
+    }));
+
+    container.innerHTML = BentoCards.renderCollection(cards);
+  },
+
+  renderEmptyState: (title, message, action) => {
+    return `
+      <div class="view-section-empty">
+        ${title ? `<h3>${title}</h3>` : ''}
+        ${message ? `<p>${message}</p>` : ''}
+        ${action ? `<button type="button" data-section-action="${action.action}">${action.label}</button>` : ''}
+      </div>
+    `;
+  },
+
+  getHeroSubtitle: () => {
+    const playlistCount = appState.playlists.length;
+    const favorites = appState.favorites.songs.size;
+    if (playlistCount && favorites) {
+      return `${playlistCount} playlists • ${favorites} favorite songs ready to spin.`;
+    }
+    if (playlistCount) {
+      return `${playlistCount} playlists curated by you.`;
+    }
+    if (favorites) {
+      return `${favorites} songs have been favorited so far.`;
+    }
+    return 'Tap play on any card to instantly fill your queue.';
+  },
+
+  getRecentSongs: (limit = 6) => {
+    return (appState.recentlyPlayed || [])
+      .slice(0, limit)
+      .map((song) => homePage.enrichSong(song));
   },
 
   getRandomAlbums: (count = 6) => {
-    if (!window.music) return [];
-
-    const allAlbums = [];
+    if (!Array.isArray(window.music) || !window.music.length) return [];
+    const pool = [];
     window.music.forEach((artist) => {
       artist.albums.forEach((album) => {
-        allAlbums.push({
+        pool.push({
+          ...album,
           artist: artist.artist,
-          album: album.album,
           cover: utils.getAlbumImageUrl(album.album),
-          songs: album.songs,
         });
       });
     });
-
-    const shuffled = [...allAlbums].sort(() => 0.5 - Math.random());
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
     return shuffled.slice(0, count);
   },
 
-  getSongsByIds: (ids) => {
-    if (!window.music || !ids.length) return [];
+  getFavoriteArtists: (limit = 6) => {
+    const names = Array.from(appState.favorites.artists || []);
+    const list = [];
+    if (names.length) {
+      names.forEach((name) => {
+        const artistData = window.music?.find((artist) => artist.artist === name);
+        if (artistData) {
+          list.push({ ...artistData, cover: utils.getArtistImageUrl(artistData.artist) });
+        }
+      });
+    }
 
-    const songs = [];
+    if (list.length < limit && Array.isArray(window.music)) {
+      const filler = window.music
+        .filter((artist) => !names.includes(artist.artist))
+        .map((artist) => ({ ...artist, cover: utils.getArtistImageUrl(artist.artist) }));
+      list.push(...filler.slice(0, limit - list.length));
+    }
+    return list.slice(0, limit);
+  },
 
+  getFavoriteSongs: (limit = 6) => {
+    const ids = Array.from(appState.favorites.songs || []);
+    const songs = homePage.getSongsByIds(ids).map((song) => homePage.enrichSong(song));
+    if (songs.length < limit) {
+      const recent = homePage.getRecentSongs(limit - songs.length);
+      recent.forEach((song) => {
+        if (!songs.some((existing) => existing.id === song.id)) {
+          songs.push(song);
+        }
+      });
+    }
+    return songs.slice(0, limit);
+  },
+
+  getSongsByIds: (ids = []) => {
+    const list = [];
+    if (!Array.isArray(window.music)) return list;
+    ids.forEach((id) => {
+      const song = homePage.findSongById(id);
+      if (song) {
+        list.push(song);
+      }
+    });
+    return list;
+  },
+
+  findSongById: (songId) => {
+    if (!songId || !Array.isArray(window.music)) return null;
+    for (const artist of window.music) {
+      for (const album of artist.albums) {
+        const song = album.songs.find((track) => track.id === songId);
+        if (song) {
+          return homePage.enrichSong({ ...song, artist: artist.artist, album: album.album });
+        }
+      }
+    }
+    return null;
+  },
+
+  enrichSong: (song) => {
+    if (!song) return song;
+    return {
+      ...song,
+      cover: song.cover || utils.getAlbumImageUrl(song.album),
+    };
+  },
+
+  bindEvents: () => {
+    const dynamicContent = $byId(IDS.dynamicContent);
+    if (!dynamicContent) return;
+
+    if (!dynamicContent._sectionActionHandler) {
+      const handler = (event) => {
+        const button = event.target.closest('[data-section-action]');
+        if (!button) return;
+        event.preventDefault();
+        homePage.handleSectionAction(button.dataset.sectionAction);
+      };
+      dynamicContent.addEventListener('click', handler);
+      dynamicContent._sectionActionHandler = handler;
+    }
+  },
+
+  handleSectionAction: (action) => {
+    switch (action) {
+      case 'shuffle-library':
+        homePage.shuffleLibrary();
+        break;
+      case 'goto-artists':
+        appState.router?.navigateTo(ROUTES.ALL_ARTISTS);
+        break;
+      case 'open-recent-tab':
+        musicPlayer.mainPlayer.open();
+        setTimeout(() => musicPlayer.mainPlayer.switchTab?.('recent'), 100);
+        break;
+      case 'view-favorite-artists':
+        views.showFavoriteArtists?.();
+        break;
+      case 'view-favorite-songs':
+        views.showFavoriteSongs?.();
+        break;
+      case 'create-playlist':
+        playlists.create()?.then?.(() => setTimeout(() => homePage.renderPlaylists(), 150));
+        break;
+      default:
+        break;
+    }
+  },
+
+  shuffleLibrary: () => {
+    if (!Array.isArray(window.music) || !window.music.length) {
+      notifications.show('No songs available to shuffle yet.');
+      return;
+    }
+    const pool = [];
     window.music.forEach((artist) => {
       artist.albums.forEach((album) => {
         album.songs.forEach((song) => {
-          if (ids.includes(song.id)) {
-            songs.push({
-              ...song,
-              artist: artist.artist,
-              album: album.album,
-              cover: utils.getAlbumImageUrl(album.album),
-            });
-          }
+          pool.push({
+            ...song,
+            artist: artist.artist,
+            album: album.album,
+            cover: utils.getAlbumImageUrl(album.album),
+          });
         });
       });
     });
-
-    return songs;
-  },
-
-  playAlbum: (artistName, albumName) => {
-    if (!window.music) return;
-
-    const artist = window.music.find((a) => a.artist === artistName);
-    if (!artist) return;
-
-    const album = artist.albums.find((a) => a.album === albumName);
-    if (!album || album.songs.length === 0) return;
-
+    if (!pool.length) {
+      notifications.show('No songs available to shuffle yet.');
+      return;
+    }
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
     appState.queue.clear();
-
-    album.songs.slice(1).forEach((song) => {
-      appState.queue.add({
-        ...song,
-        artist: artistName,
-        album: albumName,
-        cover: utils.getAlbumImageUrl(albumName),
-      });
-    });
-
-    musicPlayer.ui.playSong({
-      ...album.songs[0],
-      artist: artistName,
-      album: albumName,
-      cover: utils.getAlbumImageUrl(albumName),
-    });
-
-    notifications.show(`Playing album "${albumName}"`, NOTIFICATION_TYPES.SUCCESS);
-  },
-
-  renderEmptyState: (message, iconType) => {
-    const icons = {
-      "music-note": '<path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>',
-      album: '<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 14.5c-2.49 0-4.5-2.01-4.5-4.5S9.51 7.5 12 7.5s4.5 2.01 4.5 4.5-2.01 4.5-4.5 4.5zm0-5.5c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z"/>',
-      artist: '<path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>',
-      playlist: '<path d="M14 10H2v2h12v-2zm0-4H2v2h12V6zm4 8v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zM2 16h8v-2H2v2z"/>',
-      heart: '<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>',
-    };
-
-    const iconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-12 h-12 mb-3 opacity-50">${icons[iconType] || icons["music-note"]}</svg>`;
-    
-    return render.emptyState({
-      icon: iconSvg,
-      title: '',
-      subtitle: message
-    });
+    shuffled.slice(1).forEach((song) => appState.queue.add(song));
+    musicPlayer.ui.playSong(shuffled[0]);
+    notifications.show('Shuffling your entire library');
   },
 };
-
 export const views = {
     showFavoriteSongs: () => {
         const favoriteSongIds = Array.from(appState.favorites.songs);

--- a/siteScripts/utilities/templates.js
+++ b/siteScripts/utilities/templates.js
@@ -442,64 +442,42 @@ case "enhancedArtist":
           </div>
           <div id="artists-grid" class="artists-grid grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 px-4 sm:px-6"></div>
         `;
-      case "home_bento":
-        return `
-        <div class="bento-grid">
-            <div class="bento-card" data-loader="true">
-              <div class="card-header">
-                <h2 class="card-title">Recently Played</h2>
-                <a href="#" class="card-link" data-view="recent">View All</a>
-              </div>
-              <div id="${data.IDS.recentlyPlayedSection}" class="card-content">
-                <div class="skeleton-loader"></div>
-              </div>
-            </div>
-            
-            <div class="bento-card bento-span-2" data-loader="true">
-              <div class="card-header">
-                <h2 class="card-title">Discover Albums</h2>
-                <a href="#" class="card-link" data-view="albums">Explore More</a>
-              </div>
-              <div id="${data.IDS.randomAlbumsSection}" class="card-content">
-                <div class="skeleton-loader"></div>
-              </div>
-            </div>
-            
-            <div class="bento-card" data-loader="true">
-              <div class="card-header">
-                <h2 class="card-title">Favorite Artists</h2>
-                <a href="#" class="card-link" data-view="favorite-artists">View All</a>
-              </div>
-              <div id="${data.IDS.favoriteArtistsSection}" class="card-content">
-                <div class="skeleton-loader"></div>
-              </div>
-            </div>
-            
-            <div class="bento-card" data-loader="true">
-              <div class="card-header">
-                <h2 class="card-title">Your Playlists</h2>
-                <a href="#" class="card-link" data-view="playlists">View All</a>
-              </div>
-              <div id="${data.IDS.playlistsSection}" class="card-content">
-                <div class="skeleton-loader"></div>
-              </div>
-            </div>
-            
-            <div class="bento-card" data-loader="true">
-              <div class="card-header">
-                <h2 class="card-title">Favorite Songs</h2>
-                <a href="#" class="card-link" data-view="favorite-songs">View All</a>
-              </div>
-              <div id="${data.IDS.favoriteSongsSection}" class="card-content">
-                <div class="skeleton-loader"></div>
-              </div>
-            </div>
-          </div>
-        `;
-        
       default:
         return "";
     }
+  },
+
+  viewShell: function (config = {}) {
+    const {
+      viewId = "view",
+      accentLabel = "",
+      title = "",
+      subtitle = "",
+      description = "",
+      actions = [],
+    } = config;
+
+    const actionsHtml = actions
+      .map((action) => {
+        if (!action?.label || !action?.action) return "";
+        return `<button type="button" class="view-header-btn" data-section-action="${escapeForAttribute(action.action)}">${escapeForAttribute(action.label)}</button>`;
+      })
+      .join("");
+
+    return `
+      <main id="appView" class="bento-grid-view" data-view-id="${escapeForAttribute(viewId)}">
+        <section class="view-header">
+          <div class="view-header-copy">
+            ${accentLabel ? `<p class="view-header-eyebrow">${escapeForAttribute(accentLabel)}</p>` : ""}
+            ${title ? `<h1 class="view-header-title">${escapeForAttribute(title)}</h1>` : ""}
+            ${subtitle ? `<p class="view-header-subtitle">${escapeForAttribute(subtitle)}</p>` : ""}
+            ${description ? `<p class="view-header-subtitle">${escapeForAttribute(description)}</p>` : ""}
+          </div>
+          ${actionsHtml ? `<div class="view-header-actions">${actionsHtml}</div>` : ""}
+        </section>
+        <section class="view-grid" data-view-grid></section>
+      </main>
+    `;
   },
 
 homeSection: {

--- a/stylingSheets/pages/core.css
+++ b/stylingSheets/pages/core.css
@@ -66,3 +66,496 @@
   100% { transform: rotate(360deg); }
 }
 
+.content-blur-container {
+  transition: filter 0.3s ease, opacity 0.3s ease;
+}
+
+.content-blur-container.blur-active {
+  filter: blur(6px);
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content-blur-container {
+    transition: none;
+  }
+}
+
+/* View shell + Bento Grid Framework */
+.bento-grid-view {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .bento-grid-view {
+    padding: 2.5rem 3rem 3rem;
+  }
+}
+
+.view-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .view-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+}
+
+.view-header-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.view-header-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.view-header-title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.1;
+  font-weight: 700;
+  color: #fff;
+}
+
+.view-header-subtitle {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 1rem;
+  max-width: 720px;
+}
+
+.view-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.view-header-btn {
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+}
+
+.view-header-btn:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.view-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.view-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(32, 35, 45, 0.9), rgba(19, 20, 30, 0.85));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+@media (min-width: 768px) {
+  .view-hero {
+    flex-direction: row;
+    align-items: center;
+    padding: 2rem;
+  }
+}
+
+.view-hero-cover {
+  width: 180px;
+  flex-shrink: 0;
+  aspect-ratio: 1 / 1;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.view-hero-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.view-hero-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.view-hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.view-hero-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  margin: 0;
+  color: #fff;
+}
+
+.view-hero-subtitle {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 1rem;
+  margin: 0;
+}
+
+.view-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.view-hero-stat-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+.view-hero-stat-label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.view-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.view-hero-btn {
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+}
+
+.view-hero-btn--solid {
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #fff;
+}
+
+.view-hero-btn--ghost {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.85);
+  background: transparent;
+}
+
+.view-hero-btn:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.view-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.view-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+@media (min-width: 640px) {
+  .view-section-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+}
+
+.view-section-header h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.view-section-description {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.6);
+  max-width: 640px;
+}
+
+.view-section-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.view-section-actions button {
+  border-radius: 999px;
+  padding: 0.45rem 1.25rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.view-section-actions button:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #fff;
+}
+
+.bento-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+}
+
+@media (min-width: 1024px) {
+  .bento-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+}
+
+.bento-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 1.5rem;
+  padding: 1rem;
+  background: rgba(10, 10, 15, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+  min-height: 0;
+}
+
+.bento-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(20, 20, 30, 0.95);
+}
+
+.bento-card-media {
+  position: relative;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.4), rgba(236, 72, 153, 0.35));
+}
+
+.bento-card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bento-card-media-placeholder {
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), rgba(99, 102, 241, 0.2));
+}
+
+.bento-card-chip {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.85rem;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  letter-spacing: 0.05em;
+}
+
+.bento-card-cta {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.bento-card-cta svg {
+  width: 18px;
+  height: 18px;
+}
+
+.bento-card-cta:hover {
+  transform: scale(1.05);
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.bento-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #fff;
+}
+
+.bento-card-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.bento-card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.bento-card-meta {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+}
+
+.bento-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.bento-card-action {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.45rem 1.15rem;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.bento-card-action.btn-ghost {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.bento-card-action.btn-solid {
+  border-color: transparent;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #fff;
+}
+
+.bento-card-action.btn-icon {
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bento-card-action:hover {
+  border-color: rgba(255, 255, 255, 0.5);
+  color: #fff;
+}
+
+.bento-card-action.btn-icon:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.view-section-empty {
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.view-section-empty h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.view-section-empty p {
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.view-section-empty button {
+  margin-top: 1rem;
+  border-radius: 999px;
+  padding: 0.55rem 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+}
+
+.view-section-empty button:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+  color: #fff;
+}
+
+.media-artist {
+  background: linear-gradient(135deg, rgba(236, 72, 153, 0.35), rgba(147, 51, 234, 0.35));
+}
+
+.media-album {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.4), rgba(16, 185, 129, 0.35));
+}
+
+.media-playlist {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.4), rgba(236, 72, 153, 0.35));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bento-card,
+  .bento-card-cta,
+  .view-header-btn {
+    transition: none;
+  }
+}
+


### PR DESCRIPTION
## Summary
- rebuild `siteScripts/pages/rendering.js` so every SPA view renders through the Bento card grid, adds hero shells, and routes Artist/Album/Playlist pages through the new PageLoader-wrapped router
- wire the new Bento card component plus supporting CSS/JS helpers, enabling album-specific routes (`/album/{artist}/{album}`) and playlist navigation without trapping the user
- refresh the shared styles to cover hero headers, action buttons, and media accents so all views share the same Bento visual language

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691998cdd2e48321863af3532b3ed080)