### PR TITLE
Simplify music player progress slider

### DIFF
--- a/debug/eruda-progress-debug.js
+++ b/debug/eruda-progress-debug.js
@@ -1,0 +1,80 @@
+(() => {
+  if (window.__musicProgressDebug) {
+    console.warn('musicProgressDebug already active');
+    return;
+  }
+
+  const getEl = (id) => document.getElementById(id);
+  const bar = getEl('music-player-progress-bar');
+  const fill = getEl('music-player-progress-fill');
+  const thumb = getEl('music-player-progress-thumb');
+  const current = getEl('music-player-current-time');
+  const total = getEl('music-player-total-time');
+
+  if (!bar || !fill || !thumb) {
+    console.warn('Progress elements missing.');
+    return;
+  }
+
+  const format = (t) => {
+    if (!Number.isFinite(t)) return '0:00';
+    const m = Math.floor(t / 60);
+    const s = Math.floor(t % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${m}:${s}`;
+  };
+
+  const state = () => {
+    const rect = bar.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+    const fillRect = fill.getBoundingClientRect();
+    const percent = parseFloat(bar.getAttribute('aria-valuenow') || '0');
+    return {
+      percent: `${percent.toFixed(2)}%`,
+      barWidth: `${rect.width.toFixed(2)}px`,
+      fillWidth: `${fillRect.width.toFixed(2)}px`,
+      thumbLeft: `${thumbRect.left - rect.left}px`,
+      thumbWidth: `${thumbRect.width.toFixed(2)}px`,
+      ariaNow: bar.getAttribute('aria-valuenow'),
+      audioTime: (() => {
+        const audio = window.appState?.audio;
+        return audio ? `${format(audio.currentTime)} / ${format(audio.duration)}` : 'no audio';
+      })(),
+    };
+  };
+
+  const logState = (label) => {
+    console.log(`\n[${label}]`, state());
+  };
+
+  const track = (type) => (event) => {
+    const x = event.clientX ?? 0;
+    const rect = bar.getBoundingClientRect();
+    const pct = rect.width ? (((x - rect.left) / rect.width) * 100).toFixed(2) : 'n/a';
+    console.log(`${type}: x=${x.toFixed(2)} pct=${pct}%`, state());
+  };
+
+  const listeners = [
+    ['pointerdown', track('down')],
+    ['pointermove', track('move')],
+    ['pointerup', track('up')],
+    ['pointercancel', track('cancel')],
+  ];
+
+  listeners.forEach(([type, handler]) => bar.addEventListener(type, handler));
+
+  const uiSyncInterval = setInterval(() => logState('interval'), 1500);
+
+  const clear = () => {
+    listeners.forEach(([type, handler]) => bar.removeEventListener(type, handler));
+    clearInterval(uiSyncInterval);
+    delete window.__musicProgressDebug;
+    console.log('musicProgressDebug stopped');
+  };
+
+  window.__musicProgressDebug = { logState, stop: clear };
+
+  logState('init');
+  console.log('musicProgressDebug active. Call window.__musicProgressDebug.stop() to remove.');
+})();

--- a/index.html
+++ b/index.html
@@ -532,22 +532,17 @@
                         </div>
 
                         <div
-                          id="progressBar"
+                          id="music-player-progress-bar"
                           role="slider"
                           tabindex="0"
                           aria-valuemin="0"
                           aria-valuemax="100"
                           aria-valuenow="0"
-                          class="ytp-progress-bar-container"
+                          class="progressBar"
                         >
-                          <div class="ytp-progress-hitbox"></div>
-
-                          <div id="progressHoverPreview" class="ytp-hover-scrub-bar"></div>
-
-                          <div id="progressBuffer" class="ytp-buffer-bar"></div>
-
-                          <div id="progressFill" class="ytp-played-bar">
-                            <div id="progressThumb" class="ytp-scrubber-button"></div>
+                          <div id="music-player-progress-buffer" class="progressBuffer"></div>
+                          <div id="music-player-progress-fill" class="progressFill">
+                            <div id="music-player-progress-thumb" class="progressThumb"></div>
                           </div>
                         </div>
                       </div>

--- a/siteScripts/global.js
+++ b/siteScripts/global.js
@@ -1939,16 +1939,16 @@ const musicPlayer = {
   bindSeekBar: () => {
     const bar = $byId(IDS.progressBar);
     const thumb = $byId(IDS.progressThumb);
-    const player = musicPlayer.ui;
+    const ui = musicPlayer.ui;
     if (!bar || !thumb) return;
 
     const onPointerDown = (e) => {
         e.preventDefault();
         bar.setPointerCapture?.(e.pointerId ?? 1);
-        player.isScrubbing = true;
-        player.wasPlayingBeforeScrub = !!appState.isPlaying;
-        if (player.wasPlayingBeforeScrub) appState.audio.pause();
-        player.seekFromEvent(e, bar);
+        ui.isScrubbing = true;
+        ui.wasPlayingBeforeScrub = !!appState.isPlaying;
+        if (ui.wasPlayingBeforeScrub) appState.audio.pause();
+        ui.seekFromEvent(e, bar);
         bar.classList.add('is-dragging');
         const moveTarget = bar;
         moveTarget.addEventListener('pointermove', onPointerMove, { passive: false });
@@ -1957,22 +1957,22 @@ const musicPlayer = {
     };
 
     const onPointerMove = (e) => {
-        if (!player.isScrubbing) return;
+        if (!ui.isScrubbing) return;
         e.preventDefault();
-        player.seekFromEvent(e, bar);
+        ui.seekFromEvent(e, bar);
     };
 
     const onPointerUp = (e) => {
-        player.seekFromEvent(e, bar, true);
-        player.isScrubbing = false;
+        ui.seekFromEvent(e, bar, true);
+        ui.isScrubbing = false;
         bar.classList.remove('is-dragging', 'is-hovering');
-        if (player.wasPlayingBeforeScrub) appState.audio.play();
+        if (ui.wasPlayingBeforeScrub) appState.audio.play();
         bar.releasePointerCapture?.(e.pointerId ?? 1);
         bar.removeEventListener('pointermove', onPointerMove);
     };
 
     const onEnter = () => bar.classList.add('is-hovering');
-    const onLeave = () => { if (!player.isScrubbing) bar.classList.remove('is-hovering'); };
+    const onLeave = () => { if (!ui.isScrubbing) bar.classList.remove('is-hovering'); };
 
     bar.addEventListener('pointerdown', onPointerDown, { passive: false });
     bar.addEventListener('pointerenter', onEnter);

--- a/siteScripts/global.js
+++ b/siteScripts/global.js
@@ -1936,9 +1936,10 @@ const musicPlayer = {
       buffer.style.width = (bufferProgress * 100).toFixed(2) + "%";
     },
     
-bindSeekBar: () => {
+  bindSeekBar: () => {
     const bar = $byId(IDS.progressBar);
     const thumb = $byId(IDS.progressThumb);
+    const player = musicPlayer.ui;
     if (!bar || !thumb) return;
 
     const onPointerDown = (e) => {

--- a/siteScripts/global.js
+++ b/siteScripts/global.js
@@ -2007,9 +2007,18 @@ bindSeekBar: () => {
       const fill = QUERY(MUSIC_PLAYER.progressFill);
       const thumb = QUERY(MUSIC_PLAYER.progressThumb);
       const currentTimeElement = QUERY(MUSIC_PLAYER.currentTime);
+      const bar = QUERY(MUSIC_PLAYER.progressBar);
 
       if (fill) {
         fill.style.width = `${percent}%`;
+      }
+
+      if (thumb) {
+        thumb.style.left = `${percent}%`;
+      }
+
+      if (bar) {
+        bar.setAttribute('aria-valuenow', Math.round(percent));
       }
 
       if (currentTimeElement && isFinite(currentTime)) {

--- a/siteScripts/map.js
+++ b/siteScripts/map.js
@@ -213,10 +213,10 @@ export const IDS = Object.freeze({
   moreBtn: "moreBtn",
   queueBtn: "queueBtn",
 
-  progressBar: "progressBar",
-  progressFill: "progressFill",
-  progressThumb: "progressThumb",
-  progressBuffer: "progressBuffer",
+  progressBar: "music-player-progress-bar",
+  progressFill: "music-player-progress-fill",
+  progressThumb: "music-player-progress-thumb",
+  progressBuffer: "music-player-progress-buffer",
   currentTime: "currentTime",
   totalTime: "totalTime",
 
@@ -307,7 +307,7 @@ export const MUSIC_PLAYER = (() => {
     albumName: `${parent} #music-player-album`,
     progressSection: `${parent} .musicPlayerProgressSection`,
     progressBar: `${parent} #music-player-progress-bar`,
-    progressBuffer: `${parent} #musicPlayerProgressBuffer`,
+    progressBuffer: `${parent} #music-player-progress-buffer`,
     progressFill: `${parent} #music-player-progress-fill`,
     progressThumb: `${parent} #music-player-progress-thumb`,
     timeDisplay: `${parent} .musicPlayerTimeDisplay`,

--- a/stylingSheets/components/musicPlayer.css
+++ b/stylingSheets/components/musicPlayer.css
@@ -616,13 +616,13 @@
 .player .progressThumb {
   position: absolute;
   top: 50%;
-  right: 0;
+  left: 0;
   width: 12px;
   height: 12px;
   background: #fff;
   border-radius: 50%;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  transform: translate(50%, -50%);
+  transform: translate(-50%, -50%);
   opacity: 1;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   pointer-events: none;

--- a/stylingSheets/components/musicPlayer.css
+++ b/stylingSheets/components/musicPlayer.css
@@ -583,10 +583,10 @@
   transition: height 0.2s ease;
 }
 .player .progressBar:hover,
-.player .progressBar.isHovering {
+.player .progressBar.is-hovering {
   height: 8px;
 }
-.player .progressBar.isDragging {
+.player .progressBar.is-dragging {
   height: 8px;
 }
 
@@ -628,12 +628,12 @@
   pointer-events: none;
 }
 .player .progressBar:hover .progressThumb,
-.player .progressBar.isHovering .progressThumb {
+.player .progressBar.is-hovering .progressThumb {
   width: 16px;
   height: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 4px rgba(255, 255, 255, 0.1);
 }
-.player .progressBar.isDragging .progressThumb {
+.player .progressBar.is-dragging .progressThumb {
   width: 18px;
   height: 18px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5), 0 0 0 6px rgba(255, 255, 255, 0.15);
@@ -1886,130 +1886,6 @@
     user-select: none;
 }
 
-/* -------------------------------
-   YOUTUBE CONTAINER
---------------------------------*/
-.ytp-progress-bar-container {
-    position: relative;
-    width: 100%;
-    height: 4px;
-    cursor: pointer;
-    border-radius: 2px;
-    background: rgba(255,255,255,0.18);
-    transition: height .15s ease, transform .15s ease;
-}
-
-.ytp-progress-bar-container:hover {
-    height: 6px;
-}
-
-/* expanded track while dragging */
-.ytp-progress-bar-container.is-dragging {
-    height: 8px;
-}
-
-/* invisible hitbox like YouTube */
-.ytp-progress-hitbox {
-    position: absolute;
-    inset: -12px 0;
-    z-index: 5;
-}
-
-/* -------------------------------
-   BUFFER BAR (light gray + shimmer)
---------------------------------*/
-@keyframes yt-buffer-shimmer {
-    0% { background-position: 0% 0; }
-    100% { background-position: 200% 0; }
-}
-
-.ytp-buffer-bar {
-    position: absolute;
-    left: 0;
-    height: 100%;
-    width: 0%;
-    background: linear-gradient(
-        90deg,
-        rgba(255,255,255,0.25) 0%,
-        rgba(255,255,255,0.35) 40%,
-        rgba(255,255,255,0.25) 80%
-    );
-    background-size: 200% 100%;
-    animation: yt-buffer-shimmer 1.5s linear infinite;
-    border-radius: 2px;
-    pointer-events: none;
-}
-
-/* -------------------------------
-   HOVER SCRUB PREVIEW BAR
---------------------------------*/
-.ytp-hover-scrub-bar {
-    position: absolute;
-    height: 100%;
-    width: 0%;
-    left: 0;
-    background: rgba(255,255,255,0.35);
-    transform-origin: left;
-    opacity: 0;
-    pointer-events: none;
-    border-radius: 2px;
-    transition: opacity .15s ease, height .15s ease;
-}
-
-.ytp-progress-bar-container:hover .ytp-hover-scrub-bar {
-    opacity: 1;
-}
-
-/* -------------------------------
-   PLAYED BAR (YouTube Red)
---------------------------------*/
-.ytp-played-bar {
-    position: absolute;
-    height: 100%;
-    width: 0%;
-    background: var(--accent-primary, #ff0000);
-    border-radius: 2px;
-    transform-origin: left;
-    transition: height .15s ease;
-    pointer-events: none;
-}
-
-.ytp-progress-bar-container:hover .ytp-played-bar {
-    height: 6px;
-}
-
-.ytp-progress-bar-container.is-dragging .ytp-played-bar {
-    height: 8px;
-}
-
-/* -------------------------------
-   SCRUBBER (THE THUMB)
---------------------------------*/
-.ytp-scrubber-button {
-    position: absolute;
-    top: 50%;
-    left: 0%;
-    width: 12px;
-    height: 12px;
-    background: var(--accent-primary, #ff0000);
-    border-radius: 50%;
-    transform: translate(-50%, -50%) scale(0);
-    pointer-events: none;
-    transition: transform .15s ease;
-}
-
-.ytp-progress-bar-container:hover .ytp-scrubber-button {
-    transform: translate(-50%, -50%) scale(1);
-}
-
-.ytp-progress-bar-container.is-hovering .ytp-scrubber-button {
-    transform: translate(-50%, -50%) scale(1.25);
-}
-
-.ytp-progress-bar-container.is-dragging .ytp-scrubber-button {
-    transform: translate(-50%, -50%) scale(1.45);
-    box-shadow: 0 0 12px rgba(255,0,0,0.8);
-}
 
 
 


### PR DESCRIPTION
## Summary
- replace the music player progress markup with simplified ids and classes
- align selectors and constants for the progress slider between the HTML, JS map, and UI logic
- clean up progress bar styling to drop legacy YouTube-style classes and match the new class names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caa4be05483219f1600ab63100455)